### PR TITLE
Digifly and LK8EX1 protocols do not fulfill NMEA standard

### DIFF
--- a/skydrop/src/fc/protocols/LK8EX1.cpp
+++ b/skydrop/src/fc/protocols/LK8EX1.cpp
@@ -24,7 +24,7 @@ void protocol_lk8ex1_step()
 		bat = 1000 + (uint16_t)battery_per;
 
 	sprintf_P(tmp, PSTR("LK8EX1,%0.0f,99999,%0.0f,%d,%u,"), fc.pressure, (fc.vario * 100.0), fc.temperature / 10, bat);
-	fprintf_P(protocol_tx, PSTR("$%s*%02X\n"), tmp, protocol_nmea_checksum(tmp));
+	fprintf_P(protocol_tx, PSTR("$%s*%02X\r\n"), tmp, protocol_nmea_checksum(tmp));
 
 	//10Hz refresh
 	protocol_set_next_step(100);

--- a/skydrop/src/fc/protocols/digifly.cpp
+++ b/skydrop/src/fc/protocols/digifly.cpp
@@ -8,7 +8,7 @@ void protocol_digifly_step()
 	char tmp[83];
 
 	sprintf_P(tmp, PSTR("D,%0.2f,%0.3f,,,%0.1f,,,,,,,"), fc.vario * 10, fc.pressure, fc.temperature / 10.0);
-	fprintf_P(protocol_tx, PSTR("$%s*%02X\n"), tmp, protocol_nmea_checksum(tmp));
+	fprintf_P(protocol_tx, PSTR("$%s*%02X\r\n"), tmp, protocol_nmea_checksum(tmp));
 
 	//10Hz refresh
 	protocol_set_next_step(100);


### PR DESCRIPTION
The line ending for all NMEA protocols has to be <cr><lf> and not <lf> only as currently implemented.