### PR TITLE
"DEBUG" is now a macro calling "debug", so saving some progmem:

### DIFF
--- a/skydrop/src/debug.cpp
+++ b/skydrop/src/debug.cpp
@@ -104,6 +104,28 @@ void debug_timeout_handler()
 //	for(;;);
 }
 
+/**
+ * printf-like function to send output to the debug log or UART iff debug is enabled.
+ *
+ * \param format a printf-like format string that must reside in PROGMEM.
+ *
+ */
+void debug(const char *format, ...)
+{
+	va_list arp;
+	char msg_buff[256];
+
+	if (debug_disabled())
+		return;
+
+	va_start(arp, format);
+	vsnprintf_P(msg_buff, sizeof(msg_buff), format, arp);
+	va_end(arp);
+
+	debug_uart_send(msg_buff);
+	debug_log(msg_buff);
+}
+
 
 ISR(DEBUG_TIMER_OVF, ISR_NAKED)
 {

--- a/skydrop/src/debug.h
+++ b/skydrop/src/debug.h
@@ -9,19 +9,8 @@
 #define DEBUG_LOG_BUFFER_SIZE	2048
 
 void debug_log(char * msg);
-
-//DEBUG
-#define DEBUG(format, ...) \
-	do { \
-		if (debug_disabled())\
-			break;\
-		char msg_buff[256];\
-		const char * msg PROGMEM = PSTR(format);\
-		sprintf_P(msg_buff, msg, ##__VA_ARGS__); \
-		debug_uart_send(msg_buff);\
-		debug_log(msg_buff);\
-	} while(0)
-
+void debug(const char *format, ...);
+#define DEBUG(format, ...) debug(PSTR(format), ##__VA_ARGS__)
 
 //assert
 #define assert(cond) \


### PR DESCRIPTION
.text + .data + .bootloader: 89.0% -> 84.6%
Addtionally ensure, that message string is not longer than buffer (vsnprintf).