### PR TITLE
Store flight statistics in log file and offer file explorer for flight statistics

### DIFF
--- a/skydrop/src/gui/settings/gui_flightlog1.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog1.cpp
@@ -1,0 +1,70 @@
+/*
+ * gui_flightlog1.cpp
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#include "gui_flightlog1.h"
+#include "../gui_list.h"
+#include "../gui_dialog.h"
+#include "../../fc/conf.h"
+#include "../../fc/logger/logger.h"
+
+/**
+ * The directory, that was selected in flightlog1 stage. It will be used by flightlog2
+ * for file selection.
+ */
+char flightlog_dir[30];
+
+void gui_flightlog1_init()
+{
+	//config.system.debug_log = DEBUG_MAGIC_ON;
+
+	gui_list_set(gui_flightlog1_item, gui_flightlog1_action, logger_count(true), GUI_SETTINGS);
+}
+
+void gui_flightlog1_stop() {}
+
+void gui_flightlog1_loop()
+{
+	gui_list_draw();
+}
+
+void gui_flightlog1_irqh(uint8_t type, uint8_t * buff)
+{
+	gui_list_irqh(type, buff);
+}
+
+void gui_flightlog1_action(uint8_t index)
+{
+ 	logger_fileno(index + 1, flightlog_dir, true);
+ 	DEBUG("\n\n\nCalling FLIGHTLOG2 with %s\n", flightlog_dir);
+ 	gui_switch_task(GUI_FLIGHTLOG2);
+}
+
+void gui_flightlog1_item(uint8_t idx, char * text, uint8_t * flags, char * sub_text)
+{
+
+	if (true) {
+		logger_fileno(idx + 1, text, true);
+		strcpy(text, text + 6);         // strlen("/logs/") = 6
+		text[10] = 0;                   // strlen("2017/02/17") = 10
+		*flags |= GUI_LIST_FOLDER;
+
+		DEBUG("gui_flightlog_item(%d)=%s\n", idx, text);
+
+	} else {
+		logger_fileno(idx + 1, text, false);
+
+		strcpy(sub_text, text + 17);    // strlen("/logs/2017/02/17/") = 17
+
+		// Remove preceeding LOG_DIR:
+		strcpy(text, text + 6);         // strlen("/logs/") = 6
+		text[10] = 0;                   // strlen("2017/02/17") = 10
+		DEBUG("gui_flightlog_item(%d)=%s,%s\n", idx, text, sub_text);
+
+		*flags |= GUI_LIST_SUB_TEXT;
+	}
+}
+

--- a/skydrop/src/gui/settings/gui_flightlog1.h
+++ b/skydrop/src/gui/settings/gui_flightlog1.h
@@ -1,0 +1,26 @@
+/*
+ * gui_flightlog1.h
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#ifndef gui_flightlog1_H_
+#define gui_flightlog1_H_
+
+#include "../gui.h"
+
+void gui_flightlog1_init();
+void gui_flightlog1_stop();
+void gui_flightlog1_loop();
+void gui_flightlog1_irqh(uint8_t type, uint8_t * buff);
+void gui_flightlog1_item(uint8_t index, char * text, uint8_t * flags, char * sub_text);
+void gui_flightlog1_action(uint8_t index);
+
+/**
+ * The directory, that was selected in flightlog1 stage. It will be used by flightlog2
+ * for file selection.
+ */
+extern char flightlog_dir[30];
+
+#endif /* gui_flightlog1_H_ */

--- a/skydrop/src/gui/settings/gui_flightlog2.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog2.cpp
@@ -1,0 +1,51 @@
+/*
+ * gui_flightlog2.cpp
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#include "gui_flightlog2.h"
+#include "gui_flightlog1.h"
+#include "../gui_list.h"
+#include "../gui_dialog.h"
+#include "../../fc/conf.h"
+#include "../../fc/logger/logger.h"
+
+/**
+ * The file, that was selected in flightlog2 stage. It will be used by flightlog3.
+ */
+char flightlog_file[30];
+
+void gui_flightlog2_init()
+{
+	gui_list_set(gui_flightlog2_item, gui_flightlog2_action, logger_count(flightlog_dir, false), GUI_FLIGHTLOG1);
+}
+
+void gui_flightlog2_stop() {}
+
+void gui_flightlog2_loop()
+{
+	gui_list_draw();
+}
+
+void gui_flightlog2_irqh(uint8_t type, uint8_t * buff)
+{
+	gui_list_irqh(type, buff);
+}
+
+void gui_flightlog2_action(uint8_t index)
+{
+	logger_fileno(flightlog_dir, index + 1, flightlog_file, false);
+ 	gui_switch_task(GUI_FLIGHTLOG3);
+}
+
+void gui_flightlog2_item(uint8_t idx, char * text, uint8_t * flags, char * sub_text)
+{
+	logger_fileno(flightlog_dir, idx + 1, text, false);
+
+	strcpy(text, text + 17);    // strlen("/logs/2017/02/17/") = 17
+
+	*flags |= GUI_LIST_FOLDER;
+}
+

--- a/skydrop/src/gui/settings/gui_flightlog2.h
+++ b/skydrop/src/gui/settings/gui_flightlog2.h
@@ -1,0 +1,26 @@
+/*
+ * gui_flightlog2.h
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+
+#ifndef gui_flightlog2_H_
+#define gui_flightlog2_H_
+
+#include "../gui.h"
+
+/**
+ * The file, that was selected in flightlog2 stage. It will be used by flightlog3.
+ */
+extern char flightlog_file[30];
+
+void gui_flightlog2_init();
+void gui_flightlog2_stop();
+void gui_flightlog2_loop();
+void gui_flightlog2_irqh(uint8_t type, uint8_t * buff);
+void gui_flightlog2_item(uint8_t index, char * text, uint8_t * flags, char * sub_text);
+void gui_flightlog2_action(uint8_t index);
+
+#endif /* gui_flightlog2_H_ */

--- a/skydrop/src/gui/settings/gui_flightlog3.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog3.cpp
@@ -1,0 +1,190 @@
+/*
+ * gui_flightlog3.cpp
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#include "gui_flightlog3.h"
+#include "gui_flightlog2.h"
+#include "../gui_list.h"
+#include "../gui_dialog.h"
+#include "../../fc/conf.h"
+#include "../../fc/logger/logger.h"
+
+uint32_t log_duration;
+uint32_t log_start;
+struct flight_stats_t log_stat;
+
+/*-----------------------------------------------------------------------*/
+/* Get a string from the file                                            */
+/*-----------------------------------------------------------------------*/
+
+TCHAR* f_gets (
+	TCHAR* buff,	/* Pointer to the string buffer to read */
+	int len,		/* Size of string buffer (characters) */
+	FIL* fp			/* Pointer to the file object */
+)
+{
+	int n = 0;
+	TCHAR c, *p = buff;
+	BYTE s[2];
+	UINT rc;
+
+	while (n < len - 1) {	/* Read characters until buffer gets filled */
+		f_read(fp, s, 1, &rc);
+		if (rc != 1) break;
+		c = s[0];
+		*p++ = c;
+		n++;
+		if (c == '\n') break;		/* Break on EOL */
+	}
+	*p = 0;
+	return n ? buff : 0;			/* When no data read (eof or error), return with error. */
+}
+
+void parse_logfile(const char *filename)
+{
+	FIL fp;
+	FRESULT f_r;
+	char line[80];
+	char *p;
+
+	// Set defaults, if nothing could be found in the file:
+	log_start = time_get_local();
+	log_duration = 0;
+	log_stat.max_alt = 0;
+	log_stat.min_alt = 0;
+	log_stat.max_climb = 0;
+	log_stat.max_sink = 0;
+
+	DEBUG("parse_logfile(%s)\n", filename);
+
+	f_r = f_open(&fp, filename, FA_READ);
+	if ( f_r != FR_OK ) return;
+
+	// Read from the end of the file
+	f_lseek(&fp, f_size(&fp) - 512);
+
+	while(1) {
+		if ( f_gets(line, sizeof(line), &fp) == NULL ) break;
+
+		p = strstr_P(line, PSTR("SKYDROP-START: "));
+		if ( p != NULL ) {
+			log_start = atol(p + 15);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-DURATION-ms: "));
+		if ( p != NULL ) {
+			log_duration = atol(p + 21);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-ALT-MAX-m: "));
+		if ( p != NULL ) {
+			log_stat.max_alt = atoi(p + 19);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-ALT-MIN-m: "));
+		if ( p != NULL ) {
+			log_stat.min_alt = atoi(p + 19);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-CLIMB-MAX-cm: "));
+		if ( p != NULL ) {
+			log_stat.max_climb = atoi(p + 22);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-SINK-MAX-cm: "));
+		if ( p != NULL ) {
+			log_stat.max_sink = atoi(p + 21);
+			continue;
+		}
+	}
+	f_close(&fp);
+}
+
+void gui_flightlog3_init()
+{
+	parse_logfile(flightlog_file);
+
+	gui_list_set(gui_flightlog3_item, gui_flightlog3_action, 7, GUI_FLIGHTLOG2);
+}
+
+void gui_flightlog3_stop() {}
+
+void gui_flightlog3_loop()
+{
+	gui_list_draw();
+}
+
+void gui_flightlog3_irqh(uint8_t type, uint8_t * buff)
+{
+	gui_list_irqh(type, buff);
+}
+
+void gui_flightlog3_action(uint8_t index)
+{
+}
+
+void gui_flightlog3_item(uint8_t idx, char * text, uint8_t * flags, char * sub_text)
+{
+	uint32_t diff;
+	uint8_t sec, min, hour, day, wday, month;
+	uint16_t year;
+
+	switch (idx) {
+	case 0:
+		datetime_from_epoch(log_start, &sec, &min, &hour, &day, &wday, &month, &year);
+
+		strcpy_P(text, PSTR("Start (date):"));
+		sprintf_P(sub_text, PSTR("%02d.%02d.%04d"), day, month, year);
+		break;
+
+	case 1:
+		datetime_from_epoch(log_start, &sec, &min, &hour, &day, &wday, &month, &year);
+
+		strcpy_P(text, PSTR("Start (time):"));
+		sprintf_P(sub_text, PSTR("%02d:%02d.%02d"), hour, min, sec);
+		break;
+
+	case 2:
+		strcpy_P(text, PSTR("Duration:"));
+
+		diff = log_duration / 1000;
+		hour = diff / 3600;
+		diff %= 3600;
+		min = diff / 60;
+		diff %= 60;
+
+		if (hour > 0)
+			sprintf_P(sub_text, PSTR("%02d:%02d"), hour, min);
+		else
+			sprintf_P(sub_text, PSTR("%02d.%02d"), min, diff);
+
+		break;
+	case 3:
+		strcpy_P(text, PSTR("Altitude(max):"));
+		sprintf_P(sub_text, PSTR("%dm"), log_stat.max_alt);
+		break;
+	case 4:
+		strcpy_P(text, PSTR("Altitude(min):"));
+		sprintf_P(sub_text, PSTR("%dm"), log_stat.min_alt);
+		break;
+	case 5:
+		strcpy_P(text, PSTR("Sink(max):"));
+		sprintf_P(sub_text, PSTR("%0.1fm/s"), log_stat.max_sink / 100.0);
+		break;
+	case 6:
+		strcpy_P(text, PSTR("Climb(max):"));
+		sprintf_P(sub_text, PSTR("%0.1fm/s"), log_stat.max_climb / 100.0 );
+		break;
+	}
+
+	*flags |= GUI_LIST_SUB_TEXT;
+}
+

--- a/skydrop/src/gui/settings/gui_flightlog3.h
+++ b/skydrop/src/gui/settings/gui_flightlog3.h
@@ -1,0 +1,21 @@
+/*
+ * gui_flightlog3.h
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+
+#ifndef gui_flightlog3_H_
+#define gui_flightlog3_H_
+
+#include "../gui.h"
+
+void gui_flightlog3_init();
+void gui_flightlog3_stop();
+void gui_flightlog3_loop();
+void gui_flightlog3_irqh(uint8_t type, uint8_t * buff);
+void gui_flightlog3_item(uint8_t index, char * text, uint8_t * flags, char * sub_text);
+void gui_flightlog3_action(uint8_t index);
+
+#endif /* gui_flightlog3_H_ */


### PR DESCRIPTION
Added a "Flight log" in the settings menu to select
a previous log file and see the flight statistics again.
This is used as an extension point to store even more
valuable data inside the log file and present it to
the pilot after the flight.

Fixed the following requests:
https://github.com/fhorinek/SkyDrop/issues/208
https://github.com/fhorinek/SkyDrop/issues/73
