### PR TITLE
Store flight statistics in log file and offer file explorer for flight statistics, v2

### DIFF
--- a/skydrop/src/common.cpp
+++ b/skydrop/src/common.cpp
@@ -533,12 +533,52 @@ float atoi_f(char * str)
 	return tmp;
 }
 
+/**
+ * Returns a pointer to the last occurrence of the character c in the string s.
+ *
+ * @param s the string to look through
+ * @param c the character to search
+ *
+ * @return pointer to found character or NULL if not found.
+ */
+char *index(char * s, char c)
+{
+	while ((*s) != c) {
+		if (*s == 0) return NULL;
+		s++;
+	}
+
+	return s;
+}
+
+/**
+ * Returns a pointer to the last occurrence of the character c in the string s.
+ *
+ * @param s the string to look through
+ * @param c the character to search
+ *
+ * @return pointer to found character or NULL if not found.
+ */
+char *rindex(char * s, char c)
+{
+	char *s2 = s + strlen(s);
+
+	while ((*s2) != c) {
+		s2--;
+		if (s2 < s) return NULL;
+	}
+
+	return s2;
+}
+
+/**
+ * Find the first character after the ','.
+ *
+ * @return a pointer to the first character after ','.
+ */
 char * find_comma(char * str)
 {
-	while ((*str) != ',')
-		str++;
-
-	return (str + 1);
+	return index(str, ',') + 1;
 }
 
 uint8_t nmea_checksum(char *s)

--- a/skydrop/src/common.h
+++ b/skydrop/src/common.h
@@ -337,6 +337,26 @@ uint32_t atoi_n(char * str, uint8_t n);
 uint8_t atoi_c(char * str);
 float atoi_f(char * str);
 
+/**
+ * Returns a pointer to the last occurrence of the character c in the string s.
+ *
+ * @param s the string to look through
+ * @param c the character to search
+ *
+ * @return pointer to found character or NULL if not found.
+ */
+char *index(char * s, char c);
+
+/**
+ * Returns a pointer to the last occurrence of the character c in the string s.
+ *
+ * @param s the string to look through
+ * @param c the character to search
+ *
+ * @return pointer to found character or NULL if not found.
+ */
+char *rindex(char * s, char c);
+
 char * find_comma(char * str);
 uint8_t nmea_checksum(char *s);
 

--- a/skydrop/src/fc/fc.cpp
+++ b/skydrop/src/fc/fc.cpp
@@ -416,12 +416,19 @@ void fc_landing()
 	fc_landing_old_gui_task = gui_task;
 	gui_switch_task(GUI_DIALOG);
 
+	audio_off();
+
+
 	fc.flight.state = FLIGHT_LAND;
 	fc.flight.autostart_timer = task_get_ms_tick();
-
 	fc.flight.timer = task_get_ms_tick() - fc.flight.timer;
 
-	audio_off();
+	logger_comment(PSTR(" SKYDROP-START-s: %lu "), time_get_local());
+	logger_comment(PSTR(" SKYDROP-DURATION-ms: %lu "), fc.flight.timer);
+	logger_comment(PSTR(" SKYDROP-ALT-MAX-m: %d "), fc.flight.stats.max_alt);
+	logger_comment(PSTR(" SKYDROP-ALT-MIN-m: %d "), fc.flight.stats.min_alt);
+	logger_comment(PSTR(" SKYDROP-CLIMB-MAX-cm: %d "), fc.flight.stats.max_climb);
+	logger_comment(PSTR(" SKYDROP-SINK-MAX-cm: %d "), fc.flight.stats.max_sink);
 
 	logger_stop();
 }
@@ -650,14 +657,10 @@ void fc_log_battery()
 
 	fc_log_battery_next = task_get_ms_tick() + FC_LOG_BATTERY_EVERY;
 
-	char text[32];
-
 	if (battery_per == BATTERY_CHARGING)
-		sprintf_P(text, PSTR("bat: chrg"));
+		logger_comment(PSTR("bat: chrg"));
 	else if (battery_per == BATTERY_FULL)
-		sprintf_P(text, PSTR("bat: full"));
+		logger_comment(PSTR("bat: full"));
 	else
-		sprintf_P(text, PSTR("bat: %u%% (%u)"), battery_per, battery_adc_raw);
-
-	logger_comment(text);
+		logger_comment(PSTR("bat: %u%% (%u)"),  battery_per, battery_adc_raw);
 }

--- a/skydrop/src/fc/fc.cpp
+++ b/skydrop/src/fc/fc.cpp
@@ -423,7 +423,7 @@ void fc_landing()
 	fc.flight.autostart_timer = task_get_ms_tick();
 	fc.flight.timer = task_get_ms_tick() - fc.flight.timer;
 
-	logger_comment(PSTR(" SKYDROP-START-s: %lu "), time_get_local());
+	logger_comment(PSTR(" SKYDROP-START-s: %lu "), time_get_local() - (fc.flight.timer / 1000));
 	logger_comment(PSTR(" SKYDROP-DURATION-ms: %lu "), fc.flight.timer);
 	logger_comment(PSTR(" SKYDROP-ALT-MAX-m: %d "), fc.flight.stats.max_alt);
 	logger_comment(PSTR(" SKYDROP-ALT-MIN-m: %d "), fc.flight.stats.min_alt);

--- a/skydrop/src/fc/logger/igc.cpp
+++ b/skydrop/src/fc/logger/igc.cpp
@@ -154,10 +154,6 @@ void igc_write_grecord()
 	}
 
 	igc_writeline(line, false);
-
-	//rewind pointer
-	uint32_t pos = f_tell(&log_file);
-	assert(f_lseek(&log_file, pos - 43) == FR_OK);
 #endif
 }
 
@@ -205,7 +201,6 @@ void igc_step()
 	//B record
 	sprintf_P(line, PSTR("B%02d%02d%02d%s%s%c%05d%05.0f"), hour, min, sec, fc.gps_data.cache_igc_latitude, fc.gps_data.cache_igc_longtitude, c, alt, fc.gps_data.altitude);
 	igc_writeline(line);
-	igc_write_grecord();
 }
 
 void igc_comment(char * text)
@@ -218,5 +213,6 @@ void igc_comment(char * text)
 
 void igc_stop()
 {
+	igc_write_grecord();
 	assert(f_close(&log_file) == FR_OK);
 }

--- a/skydrop/src/fc/logger/igc.cpp
+++ b/skydrop/src/fc/logger/igc.cpp
@@ -154,6 +154,10 @@ void igc_write_grecord()
 	}
 
 	igc_writeline(line, false);
+
+	//rewind pointer
+	uint32_t pos = f_tell(&log_file);
+	assert(f_lseek(&log_file, pos - 43) == FR_OK);
 #endif
 }
 
@@ -201,6 +205,7 @@ void igc_step()
 	//B record
 	sprintf_P(line, PSTR("B%02d%02d%02d%s%s%c%05d%05.0f"), hour, min, sec, fc.gps_data.cache_igc_latitude, fc.gps_data.cache_igc_longtitude, c, alt, fc.gps_data.altitude);
 	igc_writeline(line);
+	igc_write_grecord();
 }
 
 void igc_comment(char * text)
@@ -209,10 +214,10 @@ void igc_comment(char * text)
 
 	sprintf_P(line, PSTR("L%S %s"), LOG_MID_P, text);
 	igc_writeline(line, false);
+	igc_write_grecord();
 }
 
 void igc_stop()
 {
-	igc_write_grecord();
 	assert(f_close(&log_file) == FR_OK);
 }

--- a/skydrop/src/fc/logger/logger.cpp
+++ b/skydrop/src/fc/logger/logger.cpp
@@ -117,10 +117,23 @@ void logger_step()
 	}
 }
 
-void logger_comment(char * text)
+/**
+ * printf-like function to send output to the GPS log .
+ *
+ * \param format a printf-like format string that must reside in PROGMEM.
+ *
+ */
+void logger_comment(const char *format, ...)
 {
+	va_list arp;
+	char text[80];
+
 	if (!logger_active())
 		return;
+
+	va_start(arp, format);
+	vsnprintf_P(text, sizeof(text), format, arp);
+	va_end(arp);
 
 	switch (config.logger.format)
 	{
@@ -168,16 +181,10 @@ void logger_start()
 	char path[128];
 
 	//base dir
-	sprintf_P(path, PSTR("%S"), LOG_DIR);
-	f_mkdir(path);
-	//year
-	sprintf_P(path, PSTR("%S/%04d"), LOG_DIR, year);
-	f_mkdir(path);
-	//month
-	sprintf_P(path, PSTR("%S/%04d/%02d"), LOG_DIR, year, month);
+	sprintf_P(path, PSTR("%S"), LOG_DIR_P);
 	f_mkdir(path);
 	//day
-	sprintf_P(path, PSTR("%S/%04d/%02d/%02d"), LOG_DIR, year, month, day);
+	sprintf_P(path, PSTR("%S/%04d-%02d-%02d"), LOG_DIR_P, year, month, day);
 	f_mkdir(path);
 
 	switch (config.logger.format)
@@ -218,10 +225,7 @@ void logger_stop()
 
 	if (fc.logger_state == LOGGER_WAIT_FOR_GPS)
 	{
-		char text[32];
-		strcpy_P(text, PSTR("No GPS fix during flight!"));
-
-		logger_comment(text);
+		logger_comment(PSTR("No GPS fix during flight!"));
 	}
 
 	fc.logger_state = LOGGER_IDLE;
@@ -244,4 +248,109 @@ void logger_stop()
 			aero_stop();
 		break;
 	}
+}
+
+/**
+ * Traverse dirname and return the path entry number "count" in fname.
+ * If the entry is found, then "0" is returned. Otherwise the remaining
+ * value of count is returned. E.g. if the current directory holds 3
+ * files and we look for count=5, then 2 is returned.
+ *
+ * @param dirname The name of the directory, where we start searching
+ * @param count   The number of the entry, which we are searching, start with "1"
+ * @param fname   A pointer to a memory area allocated by caller to take full filename
+ *                (including directory) of the found filename
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the remaining count.
+ */
+uint16_t logger_fileno(const char *dirname, uint16_t count, char *fname, bool dirOnly)
+{
+	FRESULT f_result;
+	DIR dir;
+	FILINFO fileinfo;
+	char next_dirname[128];
+
+	f_result = f_opendir(&dir, dirname);
+	if (f_result != FR_OK )
+		return count;
+
+	while(1) {
+		f_result = f_readdir (&dir, &fileinfo);
+		if ( fileinfo.fname[0] == 0) break;           // end of directory
+
+		if ( fileinfo.fattrib & AM_DIR ) {
+			sprintf(next_dirname, "%s/%s", dirname, fileinfo.fname);
+			count = logger_fileno(next_dirname, count, fname, dirOnly);
+			if (count == 0) break;
+		} else {
+			count--;
+			if (count == 0) {
+				if (dirOnly) {
+					sprintf(fname, "%s", dirname);
+				} else {
+					sprintf(fname, "%s/%s", dirname, fileinfo.fname);
+				}
+				break;
+			}
+			if (dirOnly) {
+				break;
+			}
+		}
+	}
+
+	f_closedir(&dir);
+
+	return count;
+}
+
+/**
+ * Traverse LOG_DIR and return the path entry number "count" in fname.
+ * If the entry is found, then "0" is returned. Otherwise the remaining
+ * value of count is returned. E.g. if the current directory holds 3
+ * files and we look for count=5, then 2 is returned.
+ *
+ * @param count   The number of the entry, which we are searching, start with "1"
+ * @param fname   A pointer to a memory area allocated by caller to take full filename
+ *                (including directory) of the found filename
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the remaining count.
+ */
+uint16_t logger_fileno(uint16_t count, char *fname, bool dirOnly)
+{
+	return logger_fileno(LOG_DIR, count, fname, dirOnly);
+}
+
+/**
+ * Return how many entries we have.
+ *
+ * @param dirname The name of the directory to search through all subdirs
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the number of path entries found.
+ */
+uint16_t logger_count(const char *dirname, bool dirOnly)
+{
+	char fname[128];
+
+	#define MAX_NUM_LOGS 1000
+
+	return MAX_NUM_LOGS - logger_fileno(dirname, MAX_NUM_LOGS, fname, dirOnly);
+}
+
+/**
+ * Return how many entries we have in the LOG_DIR directory.
+ *
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the number of path entries found.
+ */
+uint16_t logger_count(bool dirOnly)
+{
+	return logger_count(LOG_DIR, dirOnly);
 }

--- a/skydrop/src/fc/logger/logger.h
+++ b/skydrop/src/fc/logger/logger.h
@@ -8,7 +8,8 @@
 #ifndef LOGGER_H_
 #define LOGGER_H_
 
-#define LOG_DIR		PSTR("logs")
+#define LOG_DIR		"logs"
+#define LOG_DIR_P	PSTR(LOG_DIR)
 #define LOG_MID		"XSB"
 #define LOG_MID_P	PSTR(LOG_MID)
 
@@ -23,8 +24,73 @@ void logger_init();
 void logger_step();
 void logger_start();
 void logger_stop();
-void logger_comment(char * text);
+void logger_comment(const char *format, ...);
 bool logger_active();
 bool logger_error();
+
+/**
+ * Return how many entries we have in the LOG_DIR directory.
+ *
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the number of path entries found.
+ */
+uint16_t logger_count(bool onlyDir);
+
+/**
+ * Return how many entries we have.
+ *
+ * @param dirname The name of the directory to search through all subdirs
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the number of path entries found.
+ */
+uint16_t logger_count(const char *dirname, bool dirOnly);
+
+/**
+ * Traverse LOG_DIR and return the path entry number "count" in fname.
+ * If the entry is found, then "0" is returned. Otherwise the remaining
+ * value of count is returned. E.g. if the current directory holds 3
+ * files and we look for count=5, then 2 is returned.
+ *
+ * @param count   The number of the entry, which we are searching, start with "1"
+ * @param fname   A pointer to a memory area allocated by caller to take full filename
+ *                (including directory) of the found filename
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the remaining count.
+ */
+uint16_t logger_fileno(uint16_t count, char *fname, bool onlyDir);
+
+/**
+ * Traverse dirname and return the path entry number "count" in fname.
+ * If the entry is found, then "0" is returned. Otherwise the remaining
+ * value of count is returned. E.g. if the current directory holds 3
+ * files and we look for count=5, then 2 is returned.
+ *
+ * @param dirname The name of the directory, where we start searching
+ * @param count   The number of the entry, which we are searching, start with "1"
+ * @param fname   A pointer to a memory area allocated by caller to take full filename
+ *                (including directory) of the found filename
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the remaining count.
+ */
+uint16_t logger_fileno(const char *dirname, uint16_t count, char *fname, bool onlyDir);
+
+/**
+ * Return how many entries we have.
+ *
+ * @param dirname The name of the directory to search through all subdirs
+ * @param dirOnly Set to "true", if we only look for directories.
+ *                "false" means, to look for files only.
+ *
+ * @return the number of path entries found.
+ */
+uint16_t logger_count();
 
 #endif /* LOGGER_H_ */

--- a/skydrop/src/gui/gui.cpp
+++ b/skydrop/src/gui/gui.cpp
@@ -37,6 +37,9 @@
 #include "settings/set_calib.h"
 #include "settings/gui_accel_calib.h"
 #include "settings/gui_mag_calib.h"
+#include "settings/gui_flightlog1.h"
+#include "settings/gui_flightlog2.h"
+#include "settings/gui_flightlog3.h"
 
 
 lcd_display disp;
@@ -55,7 +58,8 @@ void (* gui_init_array[])() =
 	gui_set_altimeters_init, gui_set_altimeter_init, gui_set_time_init, gui_set_logger_init,
 	gui_dialog_init, gui_set_bluetooth_init, gui_update_init, gui_set_weaklift_init,
 	gui_set_menu_audio_init, gui_text_init, gui_set_advanced_init, gui_set_calib_init,
-	gui_accelerometer_calib_init, gui_mag_calib_init };
+	gui_accelerometer_calib_init, gui_mag_calib_init, gui_flightlog1_init, gui_flightlog2_init,
+	gui_flightlog3_init };
 
 void (* gui_stop_array[])() =
 	{gui_pages_stop, gui_settings_stop, gui_splash_stop, gui_set_vario_stop, gui_value_stop,
@@ -65,7 +69,8 @@ void (* gui_stop_array[])() =
 	gui_set_altimeters_stop, gui_set_altimeter_stop, gui_set_time_stop, gui_set_logger_stop,
 	gui_dialog_stop, gui_set_bluetooth_stop, gui_update_stop, gui_set_weaklift_stop,
 	gui_set_menu_audio_stop, gui_text_stop, gui_set_advanced_stop, gui_set_calib_stop,
-	gui_accelerometer_calib_stop, gui_mag_calib_stop };
+	gui_accelerometer_calib_stop, gui_mag_calib_stop, gui_flightlog1_stop, gui_flightlog2_stop,
+	gui_flightlog3_stop };
 
 void (* gui_loop_array[])() =
 	{gui_pages_loop, gui_settings_loop, gui_splash_loop, gui_set_vario_loop, gui_value_loop,
@@ -75,7 +80,8 @@ void (* gui_loop_array[])() =
 	gui_set_altimeters_loop, gui_set_altimeter_loop, gui_set_time_loop, gui_set_logger_loop,
 	gui_dialog_loop, gui_set_bluetooth_loop, gui_update_loop, gui_set_weaklift_loop,
 	gui_set_menu_audio_loop, gui_text_loop, gui_set_advanced_loop, gui_set_calib_loop,
-	gui_accelerometer_calib_loop, gui_mag_calib_loop };
+	gui_accelerometer_calib_loop, gui_mag_calib_loop, gui_flightlog1_loop, gui_flightlog2_loop,
+	gui_flightlog3_loop };
 
 void (* gui_irqh_array[])(uint8_t type, uint8_t * buff) =
 	{gui_pages_irqh, gui_settings_irqh, gui_splash_irqh, gui_set_vario_irqh, gui_value_irqh,
@@ -85,7 +91,8 @@ void (* gui_irqh_array[])(uint8_t type, uint8_t * buff) =
 	gui_set_altimeters_irqh, gui_set_altimeter_irqh, gui_set_time_irqh, gui_set_logger_irqh,
 	gui_dialog_irqh, gui_set_bluetooth_irqh, gui_update_irqh, gui_set_weaklift_irqh,
 	gui_set_menu_audio_irqh, gui_text_irqh, gui_set_advanced_irqh, gui_set_calib_irqh,
-	gui_accelerometer_calib_irqh, gui_mag_calib_irqh };
+	gui_accelerometer_calib_irqh, gui_mag_calib_irqh, gui_flightlog1_irqh, gui_flightlog2_irqh,
+	gui_flightlog3_irqh };
 
 #define GUI_ANIM_STEPS	20
 

--- a/skydrop/src/gui/gui.h
+++ b/skydrop/src/gui/gui.h
@@ -96,9 +96,12 @@ void gui_statusbar();
 #define GUI_SET_CALIB		28
 #define GUI_SET_CALIB_ACC	29
 #define GUI_SET_CALIB_MAG	30
+#define GUI_FLIGHTLOG1		31
+#define GUI_FLIGHTLOG2		32
+#define GUI_FLIGHTLOG3		33
 
 
-#define NUMBER_OF_GUI_TASKS	31
+#define NUMBER_OF_GUI_TASKS	34
 
 #define GUI_LAST_TASK		0xFF
 

--- a/skydrop/src/gui/gui_list.cpp
+++ b/skydrop/src/gui/gui_list.cpp
@@ -34,7 +34,7 @@ void gui_list_draw()
 		if (task_get_ms_tick() - gui_list_middle_hold > BUTTON_LONG)
 		{
 			gui_switch_task(gui_list_back);
-			if (config.gui.menu_audio_flags & CFG_AUDIO_MENU_BUTTONS && gui_buttons_override == false)
+			if ((config.gui.menu_audio_flags & CFG_AUDIO_MENU_BUTTONS) && gui_buttons_override == false)
 				seq_start(&snd_menu_exit, config.gui.menu_volume);
 		}
 	}

--- a/skydrop/src/gui/gui_list.h
+++ b/skydrop/src/gui/gui_list.h
@@ -24,12 +24,11 @@ void gui_list_irqh(uint8_t type, uint8_t * buff);
 #define GUI_LIST_DISABLED	0b10000000
 
 #define GUI_LIST_T_MASK		0b00111111
-#define GUI_LIST_FOLDER		0
-#define GUI_LIST_BACK		1
-#define GUI_LIST_CHECK_ON	2
-#define GUI_LIST_CHECK_OFF	3
-#define GUI_LIST_SUB_TEXT	4
 
-
+#define GUI_LIST_FOLDER		0     // An entry which is a folder containing more entries
+#define GUI_LIST_BACK		1     // The "back" entry
+#define GUI_LIST_CHECK_ON	2     // An entry with a checkbox, which is currently ON
+#define GUI_LIST_CHECK_OFF	3     // An entry with a checkbox, which is currently OFF
+#define GUI_LIST_SUB_TEXT	4     // An entry containing a text under it.
 
 #endif /* GUI_LIST_H_ */

--- a/skydrop/src/gui/settings/gui_flightlog1.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog1.cpp
@@ -1,0 +1,70 @@
+/*
+ * gui_flightlog1.cpp
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#include "gui_flightlog1.h"
+#include "../gui_list.h"
+#include "../gui_dialog.h"
+#include "../../fc/conf.h"
+#include "../../fc/logger/logger.h"
+
+/**
+ * The directory, that was selected in flightlog1 stage. It will be used by flightlog2
+ * for file selection.
+ */
+char flightlog_dir[30];
+
+void gui_flightlog1_init()
+{
+	//config.system.debug_log = DEBUG_MAGIC_ON;
+
+	gui_list_set(gui_flightlog1_item, gui_flightlog1_action, logger_count(true), GUI_SETTINGS);
+}
+
+void gui_flightlog1_stop() {}
+
+void gui_flightlog1_loop()
+{
+	gui_list_draw();
+}
+
+void gui_flightlog1_irqh(uint8_t type, uint8_t * buff)
+{
+	gui_list_irqh(type, buff);
+}
+
+void gui_flightlog1_action(uint8_t index)
+{
+ 	logger_fileno(index + 1, flightlog_dir, true);
+ 	DEBUG("\n\n\nCalling FLIGHTLOG2 with %s\n", flightlog_dir);
+ 	gui_switch_task(GUI_FLIGHTLOG2);
+}
+
+void gui_flightlog1_item(uint8_t idx, char * text, uint8_t * flags, char * sub_text)
+{
+
+	if (true) {
+		logger_fileno(idx + 1, text, true);
+		strcpy(text, text + 6);         // strlen("/logs/") = 6
+		text[10] = 0;                   // strlen("2017/02/17") = 10
+		*flags |= GUI_LIST_FOLDER;
+
+		DEBUG("gui_flightlog_item(%d)=%s\n", idx, text);
+
+	} else {
+		logger_fileno(idx + 1, text, false);
+
+		strcpy(sub_text, text + 17);    // strlen("/logs/2017/02/17/") = 17
+
+		// Remove preceeding LOG_DIR:
+		strcpy(text, text + 6);         // strlen("/logs/") = 6
+		text[10] = 0;                   // strlen("2017/02/17") = 10
+		DEBUG("gui_flightlog_item(%d)=%s,%s\n", idx, text, sub_text);
+
+		*flags |= GUI_LIST_SUB_TEXT;
+	}
+}
+

--- a/skydrop/src/gui/settings/gui_flightlog1.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog1.cpp
@@ -22,7 +22,7 @@ char flightlog_dir[30];
 
 void gui_flightlog1_init()
 {
-	gui_list_set(gui_flightlog1_item, gui_flightlog1_action, logger_count(true), GUI_SETTINGS);
+	gui_list_set(gui_flightlog1_item, gui_flightlog1_action, logger_count(true), GUI_SET_LOGGER);
 }
 
 void gui_flightlog1_stop() {}

--- a/skydrop/src/gui/settings/gui_flightlog1.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog1.cpp
@@ -1,6 +1,9 @@
 /*
  * gui_flightlog1.cpp
  *
+ * Let the user choose a log directory. If he selects one, then store that
+ * name in flightlog_dir and call gui_flightlog2.
+ *
  *  Created on: 22.02.2017
  *      Author: tilmann@bubecks.de
  */
@@ -19,8 +22,6 @@ char flightlog_dir[30];
 
 void gui_flightlog1_init()
 {
-	//config.system.debug_log = DEBUG_MAGIC_ON;
-
 	gui_list_set(gui_flightlog1_item, gui_flightlog1_action, logger_count(true), GUI_SETTINGS);
 }
 
@@ -39,32 +40,14 @@ void gui_flightlog1_irqh(uint8_t type, uint8_t * buff)
 void gui_flightlog1_action(uint8_t index)
 {
  	logger_fileno(index + 1, flightlog_dir, true);
- 	DEBUG("\n\n\nCalling FLIGHTLOG2 with %s\n", flightlog_dir);
  	gui_switch_task(GUI_FLIGHTLOG2);
 }
 
 void gui_flightlog1_item(uint8_t idx, char * text, uint8_t * flags, char * sub_text)
 {
-
-	if (true) {
-		logger_fileno(idx + 1, text, true);
-		strcpy(text, text + 6);         // strlen("/logs/") = 6
-		text[10] = 0;                   // strlen("2017/02/17") = 10
-		*flags |= GUI_LIST_FOLDER;
-
-		DEBUG("gui_flightlog_item(%d)=%s\n", idx, text);
-
-	} else {
-		logger_fileno(idx + 1, text, false);
-
-		strcpy(sub_text, text + 17);    // strlen("/logs/2017/02/17/") = 17
-
-		// Remove preceeding LOG_DIR:
-		strcpy(text, text + 6);         // strlen("/logs/") = 6
-		text[10] = 0;                   // strlen("2017/02/17") = 10
-		DEBUG("gui_flightlog_item(%d)=%s,%s\n", idx, text, sub_text);
-
-		*flags |= GUI_LIST_SUB_TEXT;
-	}
+	logger_fileno(idx + 1, text, true);
+	strcpy(text, index(text, '/') + 1);         // strlen("/logs/") = 6
+	//text[10] = 0;                   // strlen("2017/02/17") = 10
+	*flags |= GUI_LIST_FOLDER;
 }
 

--- a/skydrop/src/gui/settings/gui_flightlog1.h
+++ b/skydrop/src/gui/settings/gui_flightlog1.h
@@ -1,0 +1,26 @@
+/*
+ * gui_flightlog1.h
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#ifndef gui_flightlog1_H_
+#define gui_flightlog1_H_
+
+#include "../gui.h"
+
+void gui_flightlog1_init();
+void gui_flightlog1_stop();
+void gui_flightlog1_loop();
+void gui_flightlog1_irqh(uint8_t type, uint8_t * buff);
+void gui_flightlog1_item(uint8_t index, char * text, uint8_t * flags, char * sub_text);
+void gui_flightlog1_action(uint8_t index);
+
+/**
+ * The directory, that was selected in flightlog1 stage. It will be used by flightlog2
+ * for file selection.
+ */
+extern char flightlog_dir[30];
+
+#endif /* gui_flightlog1_H_ */

--- a/skydrop/src/gui/settings/gui_flightlog2.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog2.cpp
@@ -1,0 +1,51 @@
+/*
+ * gui_flightlog2.cpp
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#include "gui_flightlog2.h"
+#include "gui_flightlog1.h"
+#include "../gui_list.h"
+#include "../gui_dialog.h"
+#include "../../fc/conf.h"
+#include "../../fc/logger/logger.h"
+
+/**
+ * The file, that was selected in flightlog2 stage. It will be used by flightlog3.
+ */
+char flightlog_file[30];
+
+void gui_flightlog2_init()
+{
+	gui_list_set(gui_flightlog2_item, gui_flightlog2_action, logger_count(flightlog_dir, false), GUI_FLIGHTLOG1);
+}
+
+void gui_flightlog2_stop() {}
+
+void gui_flightlog2_loop()
+{
+	gui_list_draw();
+}
+
+void gui_flightlog2_irqh(uint8_t type, uint8_t * buff)
+{
+	gui_list_irqh(type, buff);
+}
+
+void gui_flightlog2_action(uint8_t index)
+{
+	logger_fileno(flightlog_dir, index + 1, flightlog_file, false);
+ 	gui_switch_task(GUI_FLIGHTLOG3);
+}
+
+void gui_flightlog2_item(uint8_t idx, char * text, uint8_t * flags, char * sub_text)
+{
+	logger_fileno(flightlog_dir, idx + 1, text, false);
+
+	strcpy(text, text + 17);    // strlen("/logs/2017/02/17/") = 17
+
+	*flags |= GUI_LIST_FOLDER;
+}
+

--- a/skydrop/src/gui/settings/gui_flightlog2.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog2.cpp
@@ -1,6 +1,9 @@
 /*
  * gui_flightlog2.cpp
  *
+ * Let the user choose a file in the previously chosen directory.
+ * The filename is stored in flightlog_file and then gui_flightlog3 is called.
+ *
  *  Created on: 22.02.2017
  *      Author: tilmann@bubecks.de
  */
@@ -44,7 +47,7 @@ void gui_flightlog2_item(uint8_t idx, char * text, uint8_t * flags, char * sub_t
 {
 	logger_fileno(flightlog_dir, idx + 1, text, false);
 
-	strcpy(text, text + 17);    // strlen("/logs/2017/02/17/") = 17
+	strcpy(text, rindex(text, '/') + 1);   // copy only basename
 
 	*flags |= GUI_LIST_FOLDER;
 }

--- a/skydrop/src/gui/settings/gui_flightlog2.h
+++ b/skydrop/src/gui/settings/gui_flightlog2.h
@@ -1,0 +1,26 @@
+/*
+ * gui_flightlog2.h
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+
+#ifndef gui_flightlog2_H_
+#define gui_flightlog2_H_
+
+#include "../gui.h"
+
+/**
+ * The file, that was selected in flightlog2 stage. It will be used by flightlog3.
+ */
+extern char flightlog_file[30];
+
+void gui_flightlog2_init();
+void gui_flightlog2_stop();
+void gui_flightlog2_loop();
+void gui_flightlog2_irqh(uint8_t type, uint8_t * buff);
+void gui_flightlog2_item(uint8_t index, char * text, uint8_t * flags, char * sub_text);
+void gui_flightlog2_action(uint8_t index);
+
+#endif /* gui_flightlog2_H_ */

--- a/skydrop/src/gui/settings/gui_flightlog3.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog3.cpp
@@ -69,9 +69,9 @@ void parse_logfile(const char *filename)
 	while(1) {
 		if ( f_gets(line, sizeof(line), &fp) == NULL ) break;
 
-		p = strstr_P(line, PSTR("SKYDROP-START: "));
+		p = strstr_P(line, PSTR("SKYDROP-START-s: "));
 		if ( p != NULL ) {
-			log_start = atol(p + 15);
+			log_start = atol(p + 17);
 			continue;
 		}
 

--- a/skydrop/src/gui/settings/gui_flightlog3.cpp
+++ b/skydrop/src/gui/settings/gui_flightlog3.cpp
@@ -1,0 +1,190 @@
+/*
+ * gui_flightlog3.cpp
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+#include "gui_flightlog3.h"
+#include "gui_flightlog2.h"
+#include "../gui_list.h"
+#include "../gui_dialog.h"
+#include "../../fc/conf.h"
+#include "../../fc/logger/logger.h"
+
+uint32_t log_duration;
+uint32_t log_start;
+struct flight_stats_t log_stat;
+
+/*-----------------------------------------------------------------------*/
+/* Get a string from the file                                            */
+/*-----------------------------------------------------------------------*/
+
+TCHAR* f_gets (
+	TCHAR* buff,	/* Pointer to the string buffer to read */
+	int len,		/* Size of string buffer (characters) */
+	FIL* fp			/* Pointer to the file object */
+)
+{
+	int n = 0;
+	TCHAR c, *p = buff;
+	BYTE s[2];
+	UINT rc;
+
+	while (n < len - 1) {	/* Read characters until buffer gets filled */
+		f_read(fp, s, 1, &rc);
+		if (rc != 1) break;
+		c = s[0];
+		*p++ = c;
+		n++;
+		if (c == '\n') break;		/* Break on EOL */
+	}
+	*p = 0;
+	return n ? buff : 0;			/* When no data read (eof or error), return with error. */
+}
+
+void parse_logfile(const char *filename)
+{
+	FIL fp;
+	FRESULT f_r;
+	char line[80];
+	char *p;
+
+	// Set defaults, if nothing could be found in the file:
+	log_start = time_get_local();
+	log_duration = 0;
+	log_stat.max_alt = 0;
+	log_stat.min_alt = 0;
+	log_stat.max_climb = 0;
+	log_stat.max_sink = 0;
+
+	DEBUG("parse_logfile(%s)\n", filename);
+
+	f_r = f_open(&fp, filename, FA_READ);
+	if ( f_r != FR_OK ) return;
+
+	// Read from the end of the file
+	f_lseek(&fp, f_size(&fp) - 512);
+
+	while(1) {
+		if ( f_gets(line, sizeof(line), &fp) == NULL ) break;
+
+		p = strstr_P(line, PSTR("SKYDROP-START: "));
+		if ( p != NULL ) {
+			log_start = atol(p + 15);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-DURATION-ms: "));
+		if ( p != NULL ) {
+			log_duration = atol(p + 21);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-ALT-MAX-m: "));
+		if ( p != NULL ) {
+			log_stat.max_alt = atoi(p + 19);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-ALT-MIN-m: "));
+		if ( p != NULL ) {
+			log_stat.min_alt = atoi(p + 19);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-CLIMB-MAX-cm: "));
+		if ( p != NULL ) {
+			log_stat.max_climb = atoi(p + 22);
+			continue;
+		}
+
+		p = strstr_P(line, PSTR("SKYDROP-SINK-MAX-cm: "));
+		if ( p != NULL ) {
+			log_stat.max_sink = atoi(p + 21);
+			continue;
+		}
+	}
+	f_close(&fp);
+}
+
+void gui_flightlog3_init()
+{
+	parse_logfile(flightlog_file);
+
+	gui_list_set(gui_flightlog3_item, gui_flightlog3_action, 7, GUI_FLIGHTLOG2);
+}
+
+void gui_flightlog3_stop() {}
+
+void gui_flightlog3_loop()
+{
+	gui_list_draw();
+}
+
+void gui_flightlog3_irqh(uint8_t type, uint8_t * buff)
+{
+	gui_list_irqh(type, buff);
+}
+
+void gui_flightlog3_action(uint8_t index)
+{
+}
+
+void gui_flightlog3_item(uint8_t idx, char * text, uint8_t * flags, char * sub_text)
+{
+	uint32_t diff;
+	uint8_t sec, min, hour, day, wday, month;
+	uint16_t year;
+
+	switch (idx) {
+	case 0:
+		datetime_from_epoch(log_start, &sec, &min, &hour, &day, &wday, &month, &year);
+
+		strcpy_P(text, PSTR("Start (date):"));
+		sprintf_P(sub_text, PSTR("%02d.%02d.%04d"), day, month, year);
+		break;
+
+	case 1:
+		datetime_from_epoch(log_start, &sec, &min, &hour, &day, &wday, &month, &year);
+
+		strcpy_P(text, PSTR("Start (time):"));
+		sprintf_P(sub_text, PSTR("%02d:%02d.%02d"), hour, min, sec);
+		break;
+
+	case 2:
+		strcpy_P(text, PSTR("Duration:"));
+
+		diff = log_duration / 1000;
+		hour = diff / 3600;
+		diff %= 3600;
+		min = diff / 60;
+		diff %= 60;
+
+		if (hour > 0)
+			sprintf_P(sub_text, PSTR("%02d:%02d"), hour, min);
+		else
+			sprintf_P(sub_text, PSTR("%02d.%02d"), min, diff);
+
+		break;
+	case 3:
+		strcpy_P(text, PSTR("Altitude(max):"));
+		sprintf_P(sub_text, PSTR("%dm"), log_stat.max_alt);
+		break;
+	case 4:
+		strcpy_P(text, PSTR("Altitude(min):"));
+		sprintf_P(sub_text, PSTR("%dm"), log_stat.min_alt);
+		break;
+	case 5:
+		strcpy_P(text, PSTR("Sink(max):"));
+		sprintf_P(sub_text, PSTR("%0.1fm/s"), log_stat.max_sink / 100.0);
+		break;
+	case 6:
+		strcpy_P(text, PSTR("Climb(max):"));
+		sprintf_P(sub_text, PSTR("%0.1fm/s"), log_stat.max_climb / 100.0 );
+		break;
+	}
+
+	*flags |= GUI_LIST_SUB_TEXT;
+}
+

--- a/skydrop/src/gui/settings/gui_flightlog3.h
+++ b/skydrop/src/gui/settings/gui_flightlog3.h
@@ -1,0 +1,21 @@
+/*
+ * gui_flightlog3.h
+ *
+ *  Created on: 22.02.2017
+ *      Author: tilmann@bubecks.de
+ */
+
+
+#ifndef gui_flightlog3_H_
+#define gui_flightlog3_H_
+
+#include "../gui.h"
+
+void gui_flightlog3_init();
+void gui_flightlog3_stop();
+void gui_flightlog3_loop();
+void gui_flightlog3_irqh(uint8_t type, uint8_t * buff);
+void gui_flightlog3_item(uint8_t index, char * text, uint8_t * flags, char * sub_text);
+void gui_flightlog3_action(uint8_t index);
+
+#endif /* gui_flightlog3_H_ */

--- a/skydrop/src/gui/settings/set_logger.cpp
+++ b/skydrop/src/gui/settings/set_logger.cpp
@@ -9,7 +9,7 @@
 
 void gui_set_logger_init()
 {
-	gui_list_set(gui_set_logger_item, gui_set_logger_action, 6, GUI_SETTINGS);
+	gui_list_set(gui_set_logger_item, gui_set_logger_action, 7, GUI_SETTINGS);
 }
 
 void gui_set_logger_stop() {}
@@ -62,12 +62,16 @@ void gui_set_logger_action(uint8_t index)
 	switch(index)
 	{
 		case(0):
+			gui_switch_task(GUI_FLIGHTLOG1);
+		break;
+
+		case(1):
 			config.logger.enabled = !config.logger.enabled;
 			eeprom_busy_wait();
 			eeprom_update_byte(&config_ee.logger.enabled, config.logger.enabled);
 		break;
 
-		case(1):
+		case(2):
 			if (logger_active())
 			{
 				gui_showmessage_P(PSTR("Cannot change\nin flight!"));
@@ -78,21 +82,21 @@ void gui_set_logger_action(uint8_t index)
 			eeprom_update_byte(&config_ee.logger.format, config.logger.format);
 		break;
 
-		case(2):
+		case(3):
 			gui_switch_task(GUI_SET_AUTOSTART);
 		break;
 
-		case(3):
+		case(4):
 			gui_text_conf((char *)config.logger.pilot, LOG_TEXT_LEN, gui_set_logger_pilot_cb);
 			gui_switch_task(GUI_TEXT);
 		break;
 
-		case(4):
+		case(5):
 			gui_text_conf((char *)config.logger.glider_type, LOG_TEXT_LEN, gui_set_logger_glider_type_cb);
 			gui_switch_task(GUI_TEXT);
 		break;
 
-		case(5):
+		case(6):
 			gui_text_conf((char *)config.logger.glider_id, LOG_TEXT_LEN, gui_set_logger_glider_id_cb);
 			gui_switch_task(GUI_TEXT);
 		break;
@@ -104,6 +108,11 @@ void gui_set_logger_item(uint8_t index, char * text, uint8_t * flags, char * sub
 	switch (index)
 	{
 		case (0):
+			sprintf_P(text, PSTR("Flight log"));
+			*flags |= GUI_LIST_FOLDER;
+		break;
+
+		case (1):
 			sprintf_P(text, PSTR("Enabled"));
 			if (config.logger.enabled)
 				*flags |= GUI_LIST_CHECK_ON;
@@ -111,7 +120,7 @@ void gui_set_logger_item(uint8_t index, char * text, uint8_t * flags, char * sub
 				*flags |= GUI_LIST_CHECK_OFF;
 		break;
 
-		case (1):
+		case (2):
 			sprintf_P(text, PSTR("Format"));
 			*flags |= GUI_LIST_SUB_TEXT;
 			switch (config.logger.format)
@@ -134,7 +143,7 @@ void gui_set_logger_item(uint8_t index, char * text, uint8_t * flags, char * sub
 			}
 		break;
 
-		case (2):
+		case (3):
 			sprintf_P(text, PSTR("Auto start/land"));
 			*flags |= GUI_LIST_SUB_TEXT;
 			if (config.autostart.flags & AUTOSTART_ALWAYS_ENABLED)
@@ -149,7 +158,7 @@ void gui_set_logger_item(uint8_t index, char * text, uint8_t * flags, char * sub
 				sprintf_P(sub_text, PSTR("disabled"));
 		break;
 
-		case (3):
+		case (4):
 			sprintf_P(text, PSTR("Pilot name"));
 			*flags |= GUI_LIST_SUB_TEXT;
 
@@ -159,7 +168,7 @@ void gui_set_logger_item(uint8_t index, char * text, uint8_t * flags, char * sub
 				gui_fit_text((char *)config.logger.pilot, sub_text, GUI_DISP_WIDTH - 2);
 		break;
 
-		case (4):
+		case (5):
 			sprintf_P(text, PSTR("Glider type"));
 			*flags |= GUI_LIST_SUB_TEXT;
 
@@ -169,7 +178,7 @@ void gui_set_logger_item(uint8_t index, char * text, uint8_t * flags, char * sub
 				gui_fit_text((char *)config.logger.glider_type, sub_text, GUI_DISP_WIDTH - 2);
 		break;
 
-		case (5):
+		case (6):
 			sprintf_P(text, PSTR("Glider id"));
 			*flags |= GUI_LIST_SUB_TEXT;
 

--- a/skydrop/src/gui/settings/settings.cpp
+++ b/skydrop/src/gui/settings/settings.cpp
@@ -3,7 +3,7 @@
 
 void gui_settings_init()
 {
-	gui_list_set(gui_settings_item, gui_settings_action, 8, GUI_PAGES);
+	gui_list_set(gui_settings_item, gui_settings_action, 7, GUI_PAGES);
 }
 
 void gui_settings_stop()
@@ -52,10 +52,6 @@ void gui_settings_action(uint8_t index)
 	case(6):
 		gui_switch_task(GUI_SET_DEBUG);
 	break;
-	case(7):
-		gui_switch_task(GUI_FLIGHTLOG1);
-	break;
-
 	}
 }
 
@@ -89,10 +85,6 @@ void gui_settings_item(uint8_t index, char * text, uint8_t * flags, char * sub_t
 		break;
 		case (6):
 			sprintf_P(text, PSTR("Debug"));
-			*flags |= GUI_LIST_FOLDER;
-		break;
-		case (7):
-			sprintf_P(text, PSTR("Flight log"));
 			*flags |= GUI_LIST_FOLDER;
 		break;
 	}

--- a/skydrop/src/gui/settings/settings.cpp
+++ b/skydrop/src/gui/settings/settings.cpp
@@ -3,7 +3,7 @@
 
 void gui_settings_init()
 {
-	gui_list_set(gui_settings_item, gui_settings_action, 7, GUI_PAGES);
+	gui_list_set(gui_settings_item, gui_settings_action, 8, GUI_PAGES);
 }
 
 void gui_settings_stop()
@@ -52,6 +52,9 @@ void gui_settings_action(uint8_t index)
 	case(6):
 		gui_switch_task(GUI_SET_DEBUG);
 	break;
+	case(7):
+		gui_switch_task(GUI_FLIGHTLOG1);
+	break;
 
 	}
 }
@@ -88,8 +91,10 @@ void gui_settings_item(uint8_t index, char * text, uint8_t * flags, char * sub_t
 			sprintf_P(text, PSTR("Debug"));
 			*flags |= GUI_LIST_FOLDER;
 		break;
-
-
+		case (7):
+			sprintf_P(text, PSTR("Flight log"));
+			*flags |= GUI_LIST_FOLDER;
+		break;
 	}
 }
 

--- a/updates/changelog.txt
+++ b/updates/changelog.txt
@@ -1,3 +1,10 @@
+Build XXXX - DD. MM. 2017
+========================================================
+ADDED:
+ * save flight statistics inside log file
+ * new file explorer under "logger" menu entry allowing
+   to see statistics in log files.
+
 Build 3416 - 22. 02. 2017
 ========================================================
 ADDED:


### PR DESCRIPTION
Added a "Flight log" in the settings menu to select
a previous log file and see the flight statistics again.
This is used as an extension point to store even more
valuable data inside the log file and present it to
the pilot after the flight.

Fixes the following requests:
#208
#73