### PR TITLE
Fix for mkdir(/logs/20170302). Directory name was too long.

### DIFF
--- a/skydrop/src/fc/logger/logger.cpp
+++ b/skydrop/src/fc/logger/logger.cpp
@@ -184,7 +184,7 @@ void logger_start()
 	sprintf_P(path, PSTR("%S"), LOG_DIR_P);
 	f_mkdir(path);
 	//day
-	sprintf_P(path, PSTR("%S/%04d-%02d-%02d"), LOG_DIR_P, year, month, day);
+	sprintf_P(path, PSTR("%S/%04d%02d%02d"), LOG_DIR_P, year, month, day);
 	f_mkdir(path);
 
 	switch (config.logger.format)


### PR DESCRIPTION
I changed the directory hierarchy from

```
├── 2017
│   ├── 02
│   │   └── 28
│   │       └── 04-1057.IGC

```
to

```
└── 20170302
    └── 134-1701.IGC

```
Because this is much more efficient for the flight log engine.

