### PR TITLE
Remove precomputed sin table and replace with sin() and cos()

### DIFF
--- a/skydrop/src/common.h
+++ b/skydrop/src/common.h
@@ -8,6 +8,8 @@
 #ifndef COMMON_H_
 #define COMMON_H_
 
+#include <math.h>
+
 #include <xlib/core/clock.h>
 #include <xlib/core/usart.h>
 #include <xlib/core/spi.h>
@@ -385,5 +387,18 @@ void bat_en_low(uint8_t mask);
 void io_init();
 void io_write(uint8_t io, uint8_t level);
 
+/**
+ * Convert an angle given in degree to radians.
+ */
+inline double to_radians(double degree) {
+    return degree / 180.0 * M_PI;
+}
+
+/**
+ * Convert an angle given in radians to degree.
+ */
+inline double to_degrees(double radians) {
+    return radians * (180.0 / M_PI);
+}
 
 #endif /* COMMON_H_ */

--- a/skydrop/src/drivers/lcd_disp.cpp
+++ b/skydrop/src/drivers/lcd_disp.cpp
@@ -454,8 +454,8 @@ void lcd_display::DrawArc(uint8_t cx,uint8_t cy,uint8_t radius,int16_t start,int
 
 	for (angle=start;angle<=end;angle++)
 	{
-		x = radius * sin(angle);
-		y = radius * sin(angle+180);
+		x = radius * sin(to_radians(angle));
+		y = radius * sin(to_radians(angle+180));
 		PutPixel(cx+x,cy + y,1);
 	}
 }

--- a/skydrop/src/drivers/lcd_disp.cpp
+++ b/skydrop/src/drivers/lcd_disp.cpp
@@ -195,8 +195,6 @@ void lcd_display::Init(Spi * spi)
 {
 	this->spi = spi;
 
-	CreateSinTable();
-
 	clip(0, 0, lcd_width, lcd_height);
 
 	GpioSetDirection(LCD_RST, OUTPUT);
@@ -456,8 +454,8 @@ void lcd_display::DrawArc(uint8_t cx,uint8_t cy,uint8_t radius,int16_t start,int
 
 	for (angle=start;angle<=end;angle++)
 	{
-		x = radius * get_sin(angle);
-		y = radius * get_sin(angle+180);
+		x = radius * sin(angle);
+		y = radius * sin(angle+180);
 		PutPixel(cx+x,cy + y,1);
 	}
 }
@@ -654,28 +652,4 @@ void lcd_display::ClearPart(uint8_t row1, uint8_t col1, uint8_t row2, uint8_t co
 			cnt++;
 		}
 	}
-}
-
-void  lcd_display::CreateSinTable(){
-	  for (int16_t i=0; i < 91; i++)
-		  sin_table[i] = sin(((float)i/180.0)*3.142);
-}
-
-float lcd_display::get_sin(uint16_t angle)
-{
-	angle = angle % 360;
-
-	if (angle < 90)
-		return this->sin_table[angle];
-	else if (angle < 180)
-		return this->sin_table[90 - (angle - 90)];
-	else if (angle < 270)
-		return -this->sin_table[angle - 180];
-	else return -this->sin_table[90 - (angle - 270)];
-}
-
-float lcd_display::get_cos(uint16_t angle)
-{
-	angle += 270;
-	return this->get_sin(angle);
 }

--- a/skydrop/src/drivers/lcd_disp.h
+++ b/skydrop/src/drivers/lcd_disp.h
@@ -24,9 +24,6 @@ private:
 	void plot8points(uint8_t cx,uint8_t cy,uint8_t x,uint8_t y,uint8_t color);
 	void plot4points(uint8_t cx,uint8_t cy,uint8_t x,uint8_t y,uint8_t color);
 
-	void CreateSinTable();
-
-	float sin_table[91];
 
 	int16_t text_x;
 	int16_t text_y;
@@ -44,9 +41,6 @@ private:
 
 	bool flip;
 public:
-	float get_cos(uint16_t angle);
-	float get_sin(uint16_t angle);
-
 	void Init(Spi * spi);
 	void Stop();
 

--- a/skydrop/src/fc/odometer.h
+++ b/skydrop/src/fc/odometer.h
@@ -9,20 +9,12 @@
 #define FC_ODOMETER_H_
 
 #include <stdint.h>
-#include <math.h>
 
 /**
  * Latitude and longitude are multiplied with GPS_MULT to get fixed point integers.
  * E.g. 48.5 will be 48500000.
  */
 #define GPS_MULT			10000000l
-
-/**
- * Convert an angle given in radians to degree.
- */
-inline double to_degrees(double radians) {
-    return radians * (180.0 / M_PI);
-}
 
 /**
  * Returns the bearing from lat1/lon1 to lat2/lon2. All parameters

--- a/skydrop/src/gui/widgets/widgets.cpp
+++ b/skydrop/src/gui/widgets/widgets.cpp
@@ -371,21 +371,21 @@ void widget_arrow(int16_t angle, uint8_t x, uint8_t y, uint8_t w, uint8_t h)
 	uint8_t s = min(w, h);
 	uint8_t mx = x + w / 2;
 	uint8_t my = y + h / 2;
-	float fsin = disp.get_sin(angle);
-	float fcos = disp.get_cos(angle);
+	float fsin = sin(angle);
+	float fcos = cos(angle);
 
 	uint8_t x1 = mx + fsin * s / 3;
 	uint8_t y1 = my + fcos * s / 3;
 	uint8_t x2 = mx - fsin * s / 5;
 	uint8_t y2 = my - fcos * s / 5;
 
-	fsin = disp.get_sin(angle + 25);
-	fcos = disp.get_cos(angle + 25);
+	fsin = sin(angle + 25);
+	fcos = cos(angle + 25);
 	uint8_t x3 = mx - fsin * s / 3;
 	uint8_t y3 = my - fcos * s / 3;
 
-	fsin = disp.get_sin(angle + 335);
-	fcos = disp.get_cos(angle + 335);
+	fsin = sin(angle + 335);
+	fcos = cos(angle + 335);
 	uint8_t x4 = mx - fsin * s / 3;
 	uint8_t y4 = my - fcos * s / 3;
 

--- a/skydrop/src/gui/widgets/widgets.cpp
+++ b/skydrop/src/gui/widgets/widgets.cpp
@@ -371,21 +371,21 @@ void widget_arrow(int16_t angle, uint8_t x, uint8_t y, uint8_t w, uint8_t h)
 	uint8_t s = min(w, h);
 	uint8_t mx = x + w / 2;
 	uint8_t my = y + h / 2;
-	float fsin = sin(angle);
-	float fcos = cos(angle);
+	float fsin = sin(to_radians(angle));
+	float fcos = cos(to_radians(angle));
 
 	uint8_t x1 = mx + fsin * s / 3;
 	uint8_t y1 = my + fcos * s / 3;
 	uint8_t x2 = mx - fsin * s / 5;
 	uint8_t y2 = my - fcos * s / 5;
 
-	fsin = sin(angle + 25);
-	fcos = cos(angle + 25);
+	fsin = sin(to_radians(angle + 25));
+	fcos = cos(to_radians(angle + 25));
 	uint8_t x3 = mx - fsin * s / 3;
 	uint8_t y3 = my - fcos * s / 3;
 
-	fsin = sin(angle + 335);
-	fcos = cos(angle + 335);
+	fsin = sin(to_radians(angle + 335));
+	fcos = cos(to_radians(angle + 335));
 	uint8_t x4 = mx - fsin * s / 3;
 	uint8_t y4 = my - fcos * s / 3;
 


### PR DESCRIPTION
This saves:

Program: 146 bytes
Data: 364 bytes

I see no runtime penalty as all other code was always using sin(), cos(), tan(): Only drawArc and draw_arrow used the cache.