### PR TITLE
CParser modified, so that various exceptions are only printed

### DIFF
--- a/skydrop/utils/ee_maper/CParser.py
+++ b/skydrop/utils/ee_maper/CParser.py
@@ -921,7 +921,7 @@ class CParser():
         except:
             if self.verbose:
                 print "Error processing function:", t
-            sys.excepthook(*sys.exc_info())
+                sys.excepthook(*sys.exc_info())
 
 
     def packingAt(self, line):
@@ -979,7 +979,8 @@ class CParser():
             return strTyp+' '+sname
         except:
             #print t
-            sys.excepthook(*sys.exc_info())
+            if self.verbose:
+                sys.excepthook(*sys.exc_info())
 
     def processVariable(self, s, l, t):
         if self.verbose:
@@ -999,7 +1000,8 @@ class CParser():
                     self.addDef('values', name, val)
         except:
             #print t, t[0].name, t.value
-            sys.excepthook(*sys.exc_info())
+            if self.verbose:
+                sys.excepthook(*sys.exc_info())
 
     def processTypedef(self, s, l, t):
         if self.verbose:


### PR DESCRIPTION
in verbose mode. The parser is unable to deal with some
language constructs (e.g. function pointers) and throws an
exception in this case. These are now only printed if verbose is on.
This is nothing new for the parser at it is already done
for some other things. My change extends them for SkyDrops
language constructs, so that we can use the mapper without
seeing many (unnecessary) exceptions cluttering the output.
By turning on verbose, they will still be shown.