### PR TITLE
Auto calibrate height

### DIFF
--- a/skydrop/src/common.cpp
+++ b/skydrop/src/common.cpp
@@ -539,7 +539,7 @@ float atoi_f(char * str)
 	uint8_t dot = 0;
 	uint8_t i = 0;
 
-	while(str[i] != ',')
+	while(ISDIGIT(str[i]) || str[i] == '.')
 	{
 		if (str[i] == '.')
 		{

--- a/skydrop/src/common.h
+++ b/skydrop/src/common.h
@@ -401,4 +401,17 @@ inline double to_degrees(double radians) {
     return radians * (180.0 / M_PI);
 }
 
+/*
+ * 0123456789 ISDIGIT
+ * ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ISALPHA
+ * 0123456789ABCDEF ISCAPITALHEX
+ * 0123456789ABCDEFabcdef ISXDIGIT
+ */
+#define ISDIGIT(c) ((c) - '0' + 0U <= 9U)
+#define ISALPHA(c) (((c) | 32) - 'a' + 0U <= 'z' - 'a' + 0U)
+#define ISCAPITALHEX(c) ((((((c) - 48U) & 255) * 23 / 22 + 4) / 7 ^ 1) <= 2U)
+#define ISXDIGIT(c) (((((((((c) - 48U) & 255) * 18 / 17 * 52 / 51 * 58 / 114 \
+     * 13 / 11 * 14 / 13 * 35 + 35) / 36 * 35 / 33 * 34 / 33 * 35 / 170 ^ 4) \
+     - 3) & 255) ^ 1) <= 2U)
+
 #endif /* COMMON_H_ */

--- a/skydrop/src/debug.h
+++ b/skydrop/src/debug.h
@@ -11,9 +11,16 @@
 void debug_log(char * msg);
 void debug(const char *format, ...);
 
-//#define DEBUG(format, ...)
-
 #define DEBUG(format, ...) debug(PSTR(format), ##__VA_ARGS__)
+
+// Set this to "1" to get additional debug information as DEBUG_1 will be compiled in
+#define DEBUGLEVEL 0
+
+#if DEBUGLEVEL > 0
+#define DEBUG_1(args ...) DEBUG(args)
+#else
+#define DEBUG_1(args ...) do { } while (0)
+#endif
 
 //assert
 //#define assert

--- a/skydrop/src/drivers/lcd_disp.cpp
+++ b/skydrop/src/drivers/lcd_disp.cpp
@@ -19,7 +19,7 @@ void lcd_display::GotoXY(int16_t x, int16_t y)
 
 uint32_t lcd_display::clip(uint8_t x1,uint8_t y1,uint8_t x2,uint8_t y2)
 {
-	uint32_t oldClip = (clip_x1 << 24 | clip_y1 << 16 | clip_x2 << 8 | clip_y2);
+	uint32_t oldClip = ((uint32_t)clip_x1 << 24 | (uint32_t)clip_y1 << 16 | (uint32_t)clip_x2 << 8 | (uint32_t)clip_y2);
 
 	clip_x1 = x1;
 	clip_y1 = y1;
@@ -30,7 +30,7 @@ uint32_t lcd_display::clip(uint8_t x1,uint8_t y1,uint8_t x2,uint8_t y2)
 }
 
 uint32_t lcd_display::clip(uint32_t x1y1x2y2) {
-	uint32_t oldClip = (clip_x1 << 24 | clip_y1 << 16 | clip_x2 << 8 | clip_y2);
+	uint32_t oldClip = ((uint32_t)clip_x1 << 24 | (uint32_t)clip_y1 << 16 | (uint32_t)clip_x2 << 8 | (uint32_t)clip_y2);
 
 	clip_x1 = (x1y1x2y2 >> 24) & 0xff;
 	clip_y1 = (x1y1x2y2 >> 16) & 0xff;

--- a/skydrop/src/drivers/sensors/gps_l80.h
+++ b/skydrop/src/drivers/sensors/gps_l80.h
@@ -10,6 +10,13 @@
 
 #include "../../common.h"
 
+// The product specifications of the sensor says, that GPS position has a horizontal accuracy of 2.5m.
+// We understand that for a HDOP of 1.0
+#define L80_HACCURACY 2.5
+
+// This is the vertical accuracy in m. It is not found anywhere but estimated by tilmann-at-bubecks.de
+#define L80_VACCURACY 30.0
+
 void gps_init();
 void gps_change_uart_baudrate();
 void gps_start();

--- a/skydrop/src/fc/agl.cpp
+++ b/skydrop/src/fc/agl.cpp
@@ -1,9 +1,26 @@
-#include "agl.h"
+#include <debug.h>
+#include <drivers/audio/sequencer.h>
+#include <drivers/sensors/gps_l80.h>
+#include <drivers/storage/FatFs/ff.h>
+#include <drivers/storage/storage.h>
+#include <drivers/time.h>
+#include <fc/agl.h>
+#include <fc/conf.h>
+#include <fc/fc.h>
+#include <float.h>
+#include <gui/gui.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <tasks/tasks.h>
+#include <xlib/common.h>
+#include <xlib/pgmhack.h>
 
-#include "fc.h"
-#include "../drivers/storage/storage.h"
-
+// This is the file handle to the current opened HGT file
 FIL agl_data_file;
+
+// This is the gradient of the current GPS position.
+float agl_gradient;
 
 // The SRMT HGT file format is described in detail in
 //     http://dds.cr.usgs.gov/srtm/version2_1/Documentation/SRTM_Topo.pdf
@@ -84,21 +101,16 @@ void agl_open_file(char * fn)
 }
 
 /**
- * Return the heigth of ground level for the given lat/lon above sea level.
+ * Return the height of ground level for the given lat/lon above sea level.
+ * This function assumes, that the right file containing lat/lon is already
+ * opened and accessible by agl_data_file.
  *
  * @param lat the latitude of the point
  * @param lon the longitude of the point
  *
- * @return the height of the ground above sea level in m
- *
- * The correctness of this method can be checked with
- * http://api.geonames.org/srtm1?lat=47.59272333333333333333&lng=7.65589666666666666666&username=demo
- *
- * The access to the provided HGT files can be checked with
- * gdallocationinfo -wgs84 N47E007.HGT 7.65589666666666666666 47.59272333333333333333
- *   Location: (2361P,1466L), Value: 285
+ * @return the height of the ground above sea level in m or AGL_INVALID
  */
-int16_t agl_get_alt(int32_t lat, int32_t lon)
+int16_t agl_get_alt_on_opened_file(int32_t lat, int32_t lon)
 {
 	uint16_t num_points_x;
 	uint16_t num_points_y;
@@ -143,7 +155,7 @@ int16_t agl_get_alt(int32_t lat, int32_t lon)
 
 	//seek to position
 	uint32_t pos = ((uint32_t)x + num_points_x * (uint32_t)((num_points_y - y) - 1)) * 2;
-	DEBUG("agl_get_alt: lat=%ld, lon=%ld; x=%d, y=%d; pos=%ld\n", lat, lon, x, y, pos);
+	DEBUG("agl_get_alt_on_opened_file: lat=%ld, lon=%ld; x=%d, y=%d; pos=%ld\n", lat, lon, x, y, pos);
 
 	assert(f_lseek(&agl_data_file, pos) == FR_OK);
 	assert(f_read(&agl_data_file, tmp, 4, &rd) == FR_OK);
@@ -178,37 +190,170 @@ int16_t agl_get_alt(int32_t lat, int32_t lon)
 	float alt2 = alt21.int16 + float(alt22.int16 - alt21.int16) * lat_dr;
 
 	alt = alt1 + float(alt2 - alt1) * lon_dr;
-	DEBUG("alt11=%d, alt21=%d, alt12=%d, alt22=%d, alt=%d\n", alt11.int16, alt21.int16, alt12.int16, alt22.int16, alt);
+	DEBUG_1("alt11=%d, alt21=%d, alt12=%d, alt22=%d, alt=%d\n", alt11.int16, alt21.int16, alt12.int16, alt22.int16, alt);
+
+	/* Find the minimum altitude: */
+	int16_t alt_min = min(alt11.int16, alt12.int16);
+	alt_min = min(alt_min, alt21.int16);
+	alt_min = min(alt_min, alt22.int16);
+
+	/* Find the maximum altitude: */
+	int16_t alt_max = max(alt11.int16, alt12.int16);
+	alt_max = max(alt_max, alt21.int16);
+	alt_max = max(alt_max, alt22.int16);
+
+	/*
+	 * Compute the gradient of the area. This is done in a very simple (and not 100% correct way):
+	 * We simply take the ground level difference and the width of 1 degree, which is 111.3km.
+	 * We do not take into account, at which edge the minimum and maximum is and we do not care
+	 * about the fact, that 1 degree of lat is not always 111.3km and also do not take care of
+	 * coord_div_x != coord_div_y for some cases. So we only get a very rough idea of the gradient.
+	 *
+	 * However, the mistake which we do is quite constant, if we stay roughly at the same position
+	 * on earth. So it should be good enough for our needs.
+	 */
+	agl_gradient = (alt_max - alt_min) / (111300.0 / num_points_x);
 
 	return alt;
 }
 
+/**
+ * Return the height of ground level for the given lat/lon above sea level.
+ *
+ * @param lat the latitude of the point
+ * @param lon the longitude of the point
+ *
+ * @return the height of the ground above sea level in m or AGL_INVALID
+ *
+ * The correctness of this method can be checked with
+ * http://api.geonames.org/srtm1?lat=47.59272333333333333333&lng=7.65589666666666666666&username=demo
+ *
+ * The access to the provided HGT files can be checked with
+ * gdallocationinfo -wgs84 N47E007.HGT 7.65589666666666666666 47.59272333333333333333
+ *   Location: (2361P,1466L), Value: 285
+ */
+int16_t agl_get_alt(int32_t latitude, int32_t longtitude) {
+	char tmp_name[10];
+
+	if (!storage_ready())
+		return AGL_INVALID;
+
+	agl_get_filename(tmp_name, latitude, longtitude);
+
+	if (strcmp(tmp_name, (char *)fc.agl.filename) != 0)  //data file is different then previous
+		agl_open_file(tmp_name);
+
+	if (!fc.agl.file_valid) //file was not found
+		return AGL_INVALID;
+
+	return agl_get_alt_on_opened_file(fc.gps_data.latitude, fc.gps_data.longtitude);
+}
+
+
+/**
+ * We have a new GPS position and try to calibrate the ALT1 value.
+ * We check different height sources: get their height and their associated height error.
+ * At the end of the function use the best height source if the error is better than the existing error.
+ *
+ */
+void calibrate_alt()
+{
+	enum BEST_HEIGHT_SOURCE { BH_NONE, BH_HAGL, BH_GPS, BH_ALT1 };
+	float height_min_error = FLT_MAX;
+	float best_height = fc.altitude1;
+	float error;
+	enum BEST_HEIGHT_SOURCE best_height_source = BH_NONE;
+	char message[80];
+
+	//
+	// Option 1: Try vario height from barometer
+	//
+	if ( fc.vario.valid ) {
+		// Because QNH1 changes all the time, the resulting altitude1 gets wrong over time.
+		// We assume, that the error is VARIO_ERROR_PER_HOUR meter per hour.
+		// This means, that with every hour going by, the altitude1 is assumed to be wrong
+		// by VARIO_ERROR_PER_HOUR meters.
+		#define VARIO_ERROR_PER_HOUR 30.0               // must be float!
+		#define VARIO_ERROR_PER_MS  (VARIO_ERROR_PER_HOUR / (3600.0 * 1000.0))
+
+		DEBUG_1("%s:%d: fc.vario.time_of_last_error_update=%ld ", __FILE__, __LINE__, fc.vario.time_of_last_error_update);
+		DEBUG_1("%s:%d: task_get_ms_tick=%ld ", __FILE__, __LINE__, task_get_ms_tick());
+		DEBUG_1("%s:%d: fc.vario.error_over_time=%f\n", __FILE__, __LINE__, fc.vario.error_over_time);
+
+		fc.vario.error_over_time += (task_get_ms_tick() - fc.vario.time_of_last_error_update) * VARIO_ERROR_PER_MS;
+		fc.vario.time_of_last_error_update = task_get_ms_tick();
+		DEBUG_1("%s:%d: fc.vario.error_over_time=%f\n", __FILE__, __LINE__, fc.vario.error_over_time);
+
+		height_min_error = fc.vario.error_over_time;
+		best_height_source = BH_ALT1;
+		best_height = fc.altitude1;
+		DEBUG("vario: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
+	}
+
+	// Find the best height, that we have:
+	if ( fc.gps_data.valid ) {
+		//
+		// Option 1: Try ground level
+		//
+		if ( fc.flight.state != FLIGHT_FLIGHT ) {
+			if ( fc.gps_data.ground_speed < FC_GLIDE_MIN_KNOTS ) {
+				if ( fc.gps_data.hdop != 0 ) {
+					error = fc.agl.ground_gradient * fc.gps_data.hdop * L80_HACCURACY;
+					if ( error < height_min_error ) {
+						height_min_error = error;
+						best_height_source = BH_HAGL;
+						best_height = fc.agl.ground_level;
+						DEBUG("GL: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
+					}
+				}
+			}
+		}
+
+		//
+		// Option 2: Try GPS height
+		//
+		if ( fc.gps_data.vdop != 0 && fc.gps_data.vdop < height_min_error ) {
+			height_min_error = fc.gps_data.vdop * L80_VACCURACY;
+			best_height_source = BH_GPS;
+			best_height = fc.gps_data.altitude;
+			DEBUG("GPS height: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
+		}
+	}
+
+	DEBUG_1("Best altitude: now=%fm previous=%fm source=%d error=%fm\n", best_height, fc.altitude1, best_height_source, height_min_error);
+
+	float height_delta = best_height - fc.altitude1;
+
+	if ( abs(height_delta) > 10 ) {
+		DEBUG("Calibrating altitude: now=%fm previous=%fm source=%d error=%fm\n", best_height, fc.altitude1, best_height_source, height_min_error);
+		sprintf_P(message, PSTR("QNH1 cal'ed:\n%0.0fm -> %0.0fm"), fc.altitude1, best_height);
+		gui_showmessage(message);
+
+		fc_manual_alt0_change(best_height);
+		config.altitude.QNH1 = fc_alt_to_qnh(best_height, fc.vario.pressure);
+		fc.vario.error_over_time = height_min_error;
+
+		for (uint8_t i = 0; i < NUMBER_OF_ALTIMETERS; i++)
+		{
+			if (config.altitude.altimeter[i].flags & ALT_AUTO_GPS) {
+				fc.altitudes[i] += height_delta;
+			}
+		}
+	}
+}
+
 void agl_step()
 {
-	if (!storage_ready())
-		return;
-
 	if (fc.gps_data.new_sample & FC_GPS_NEW_SAMPLE_AGL)
 	{
-		char tmp_name[10];
-		agl_get_filename(tmp_name, fc.gps_data.latitude, fc.gps_data.longtitude);
-
-		if (strcmp(tmp_name, (char *)fc.agl.filename) == 0) //data file is the same as actual
-		{
-			//clear this flag only after dat file was opened
+		fc.agl.ground_gradient = AGL_INVALID;
+		fc.agl.ground_level = agl_get_alt(fc.gps_data.latitude, fc.gps_data.longtitude);
+		if (fc.agl.ground_level != AGL_INVALID) {
 			fc.gps_data.new_sample &= ~FC_GPS_NEW_SAMPLE_AGL;
-
-			if (!fc.agl.file_valid) //file was not found
-				return;
-
-			//get ground level
-			fc.agl.ground_level = agl_get_alt(fc.gps_data.latitude, fc.gps_data.longtitude);
+			fc.agl.ground_gradient = agl_gradient;
+			DEBUG("AGL: lat/lon: %f %f GL: %d GL_GRAD: %f\n", fc.gps_data.latitude * 1.0 / HGT_COORD_MUL, fc.gps_data.longtitude * 1.0 / HGT_COORD_MUL, fc.agl.ground_level, fc.agl.ground_gradient);
 		}
-		else //data file is different than actual
-		{
-			//try to open data file
-			agl_open_file(tmp_name);
-		}
+		calibrate_alt();
 	}
 }
 

--- a/skydrop/src/fc/agl.cpp
+++ b/skydrop/src/fc/agl.cpp
@@ -287,7 +287,7 @@ void calibrate_alt()
 		height_min_error = fc.vario.error_over_time;
 		best_height_source = BH_ALT1;
 		best_height = fc.altitude1;
-		DEBUG("vario: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
+		DEBUG("calibrate_alt/vario: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
 	}
 
 	// Find the best height, that we have:
@@ -296,14 +296,14 @@ void calibrate_alt()
 		// Option 1: Try ground level
 		//
 		if ( fc.flight.state != FLIGHT_FLIGHT ) {
-			if ( fc.gps_data.ground_speed < FC_GLIDE_MIN_KNOTS ) {
+			if ( fc.gps_data.groud_speed < FC_GLIDE_MIN_KNOTS ) {
 				if ( fc.gps_data.hdop != 0 ) {
 					error = fc.agl.ground_gradient * fc.gps_data.hdop * L80_HACCURACY;
 					if ( error < height_min_error ) {
 						height_min_error = error;
 						best_height_source = BH_HAGL;
 						best_height = fc.agl.ground_level;
-						DEBUG("GL: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
+						DEBUG("calibrate_alt/GL: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
 					}
 				}
 			}
@@ -312,15 +312,16 @@ void calibrate_alt()
 		//
 		// Option 2: Try GPS height
 		//
-		if ( fc.gps_data.vdop != 0 && fc.gps_data.vdop < height_min_error ) {
-			height_min_error = fc.gps_data.vdop * L80_VACCURACY;
+		error = fc.gps_data.vdop * L80_VACCURACY;
+		if ( fc.gps_data.vdop != 0 && error < height_min_error ) {
+			height_min_error = error;
 			best_height_source = BH_GPS;
 			best_height = fc.gps_data.altitude;
-			DEBUG("GPS height: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
+			DEBUG("calibrate_alt/GPS height: best_height=%f, height_min_error=%f\n", best_height, height_min_error);
 		}
 	}
 
-	DEBUG_1("Best altitude: now=%fm previous=%fm source=%d error=%fm\n", best_height, fc.altitude1, best_height_source, height_min_error);
+	DEBUG_1("calibrate_alt/Best altitude: now=%fm previous=%fm source=%d error=%fm\n", best_height, fc.altitude1, best_height_source, height_min_error);
 
 	float height_delta = best_height - fc.altitude1;
 

--- a/skydrop/src/fc/agl.h
+++ b/skydrop/src/fc/agl.h
@@ -11,6 +11,7 @@
 #include "../common.h"
 
 void agl_init();
+int16_t agl_get_alt(int32_t latitude, int32_t longtitude);
 void agl_step();
 
 #define AGL_INVALID -32767

--- a/skydrop/src/fc/conf.cpp
+++ b/skydrop/src/fc/conf.cpp
@@ -118,7 +118,7 @@ EEMEM cfg_t config_ee = {
 		//QNH2
 		101325,
 		//atl1_flags
-		ALT_UNIT_M,
+		ALT_UNIT_M | ALT_AUTO_GPS,
 		//altimeter
 		{
 			//altimeter2
@@ -145,7 +145,7 @@ EEMEM cfg_t config_ee = {
 			//altimeter5
 			{
 				//flags
-				ALT_ABS_QNH2,
+				ALT_ABS_QNH2 | ALT_AUTO_GPS,
 				//diff
 				0,
 			},

--- a/skydrop/src/fc/fc.h
+++ b/skydrop/src/fc/fc.h
@@ -43,13 +43,14 @@
 #define ALT_ABS_GPS		0b10000000
 #define ALT_DIFF		0b11000000
 
-#define ALT_REL_MASK	0b00001111
+#define ALT_REL_MASK	0b00000111
 
 //single bit flags
 #define ALT_UNIT_M		0b00000000
 #define ALT_UNIT_I		0b00100000
 
 #define ALT_AUTO_ZERO	0b00010000
+#define ALT_AUTO_GPS	0b00001000
 
 #define GPS_SAT_CNT	12
 #define GPS_FIX_CNT_MAX		200
@@ -68,6 +69,7 @@
 #define FC_GPS_NEW_SAMPLE_WIND			0b00000010
 #define FC_GPS_NEW_SAMPLE_AGL			0b00000100
 #define FC_GPS_NEW_SAMPLE_ODO			0b00001000
+#define FC_GPS_NEW_SAMPLE_ALT			0b00010000
 
 struct gps_data_t
 {
@@ -96,10 +98,12 @@ struct gps_data_t
 	float heading;
 	uint32_t utc_time;
 
-	uint8_t fix;
+	uint8_t fix;        // GPGSA.fix: 1=No Fix, 2=2D fix, 3=3D fix
 	float altitude;
 	float geoid;
 	float hdop;
+	float vdop;
+	float pdop;
 
 	uint8_t sat_used;
 	uint8_t sat_total;
@@ -107,7 +111,7 @@ struct gps_data_t
 	uint8_t sat_id[GPS_SAT_CNT];
 	uint8_t sat_snr[GPS_SAT_CNT];
 
-	uint8_t fix_cnt;
+	uint8_t fix_cnt;     // number of fixes received since the first fix (kind of quality of fix).
 };
 
 struct accel_data_t
@@ -173,6 +177,9 @@ struct vario_data_t
 
 	float digital;
 	float avg;
+
+	uint32_t time_of_last_error_update;        // time in ms since the last error_over_time update
+	float error_over_time;                     // This stores the error asscoiated with altitude1 in m.
 };
 
 struct flight_stats_t
@@ -218,8 +225,9 @@ struct agl_data_t
 	bool valid;
 	bool file_valid;
 
-	char filename[10];
-	int16_t ground_level;
+	char filename[10];        // The filename of the currently opened HAGL file
+	int16_t ground_level;     // The ground level of the current GPS position or "AGL_INVALID".
+	float ground_gradient;    // the gradient of the current GPS position
 };
 
 #define FC_GLIDE_MIN_KNOTS		(1.07) //2km/h

--- a/skydrop/src/fc/vario.cpp
+++ b/skydrop/src/fc/vario.cpp
@@ -11,6 +11,11 @@ void vario_init(float pressure )
 	fc.vario.avg = 0;
 	fc.vario.digital = 0;
 
+	// This would result in QNH1 (and altitude1) as having an update looong ago, so with a big error.
+	// This would mean, that QNH1 (and altitude1) will be calibrated to GPS on the first fix.
+	fc.vario.time_of_last_error_update = 0;
+	fc.vario.error_over_time = 100;
+
 	for (uint8_t i = 0; i < VARIO_HISTORY_SIZE; i++)
 		fc.vario.history[i] = 0;
 

--- a/skydrop/src/gui/settings/set_altimeter.cpp
+++ b/skydrop/src/gui/settings/set_altimeter.cpp
@@ -106,6 +106,8 @@ void gui_set_altimeter_gps_alt(uint8_t ret)
 			if (a_type == ALT_ABS_QNH1)
 			{
 				config.altitude.QNH1 = fc_alt_to_qnh(fc.gps_data.altitude, fc.vario.pressure);
+				fc.vario.error_over_time = 0;
+				fc.vario.time_of_last_error_update = task_get_ms_tick();
 				fc_manual_alt0_change(fc.gps_data.altitude);
 			}
 
@@ -184,6 +186,8 @@ void gui_set_altimeter_action(uint8_t index)
 
 	if ((index == 4 && set_alt_list_num == 5) || index == 2)
 	{
+		set_alt_flags ^= ALT_AUTO_GPS;
+/*
 		if (fc.gps_data.valid)
 		{
 			char tmp_msg[64];
@@ -215,6 +219,7 @@ void gui_set_altimeter_action(uint8_t index)
 		{
 			gui_showmessage_P(PSTR("No GPS fix"));
 		}
+		*/
 	}
 }
 
@@ -276,8 +281,12 @@ void gui_set_altimeter_item(uint8_t index, char * text, uint8_t * flags, char * 
 		return;
 	}
 
-	if ((index == 4 && set_alt_list_num == 5) ||index == 2)
-		strcpy_P(text, PSTR("Get from GPS"));
-
+	if ((index == 4 && set_alt_list_num == 5) || index == 2) {
+		strcpy_P(text, PSTR("Auto from GPS"));
+		if (set_alt_flags & ALT_AUTO_GPS)
+			*flags |= GUI_LIST_CHECK_ON;
+		else
+			*flags |= GUI_LIST_CHECK_OFF;
+	}
 }
 

--- a/skydrop/src/gui/settings/set_gps_detail.cpp
+++ b/skydrop/src/gui/settings/set_gps_detail.cpp
@@ -16,14 +16,16 @@ void gui_set_gps_detail_stop() {}
 void gui_set_gps_detail_loop()
 {
 	disp.LoadFont(F_TEXT_S);
-	uint8_t f_h = disp.GetAHeight();
+	uint8_t f_h = disp.GetAHeight() + 1;
 
-	disp.GotoXY(1, 0);
+	disp.GotoXY(0, 0);
 	fprintf_P(lcd_out, PSTR("Lat: %s"), fc.gps_data.cache_gui_latitude);
 	disp.GotoXY(0, f_h);
 	fprintf_P(lcd_out, PSTR("Lon: %s"), fc.gps_data.cache_gui_longtitude);
 	disp.GotoXY(0, f_h * 2);
-	fprintf_P(lcd_out, PSTR("HDOP: %0.4f"), fc.gps_data.hdop);
+	fprintf_P(lcd_out, PSTR("HDOP: %5.2f     VDOP: %5.2f"), fc.gps_data.hdop, fc.gps_data.vdop);
+	disp.GotoXY(0, f_h * 3);
+	fprintf_P(lcd_out, PSTR("PDOP: %5.2f     Alt: %6.1f"), fc.gps_data.pdop, fc.gps_data.altitude);
 
 	char tmp[10];
 
@@ -42,9 +44,6 @@ void gui_set_gps_detail_loop()
 		break;
 	}
 	gui_raligh_text(tmp, GUI_DISP_WIDTH, f_h);
-
-	sprintf_P(tmp, PSTR("%0.0f"), fc.gps_data.altitude);
-	gui_raligh_text(tmp, GUI_DISP_WIDTH, f_h * 2);
 
 	disp.LoadFont(F_TEXT_S);
 	for (uint8_t i=0; i < GPS_SAT_CNT; i++)

--- a/skydrop/src/gui/widgets/altitude.cpp
+++ b/skydrop/src/gui/widgets/altitude.cpp
@@ -102,6 +102,8 @@ void widget_alt_menu_irqh(uint8_t type, uint8_t * buff, uint8_t index)
 
 				fc_manual_alt0_change(new_alt);
 				config.altitude.QNH1 = fc_alt_to_qnh(new_alt, fc.vario.pressure);
+				fc.vario.error_over_time = 0;
+				fc.vario.time_of_last_error_update = task_get_ms_tick();
 			break;
 
 			case(ALT_ABS_QNH2):
@@ -175,6 +177,9 @@ void widget_alt_menu_loop(uint8_t alt_index)
 				fc_manual_alt0_change(new_alt);
 
 				config.altitude.QNH1 = fc_alt_to_qnh(new_alt, fc.vario.pressure);
+				fc.vario.error_over_time = 0;
+				fc.vario.time_of_last_error_update = task_get_ms_tick();
+
 			break;
 
 			case(ALT_ABS_QNH2):

--- a/skydrop/src/tasks/tasks.cpp
+++ b/skydrop/src/tasks/tasks.cpp
@@ -79,6 +79,7 @@ ISR(USB_CONNECTED_IRQ)
 	//usb_in is checked in main loop
 }
 
+// This variable is monotonically increasing and gives the number of milliseconds since device start.
 uint32_t old_tick = 0;
 
 uint32_t task_get_ms_tick_once()

--- a/skydrop/src/xlib/common.h
+++ b/skydrop/src/xlib/common.h
@@ -47,6 +47,8 @@
 #define max(a,b) 	((a)>(b)?(a):(b))
 #define abs(x) 		((x)>0?(x):-(x))
 
+// If "val" if between "min" and "max", then return "val".
+// Otherwise return "min" or "max" depending on where "val" is.
 #define CLAMP(val, min, max)	((val < min) ? (min) : ((val > max) ? max : val))
 
 #ifdef __cplusplus


### PR DESCRIPTION
    This automatically calibrates altitude1 from different altitude sources:
     * GPS height
     * ground level of current GPS position (if not FLIGHT)
    It takes the best height source and compares its error value with
    the accumulated error value of alitude1. Altitude1 has an error over time,
    because pressure changes and therefore we assume an error of 30m per hour.
    If there is a better height than altitude1 then altitude1 is set to
    this value.

Fixes https://github.com/fhorinek/SkyDrop/issues/321