### PR TITLE
configurator: fixed compass heading points widget

### DIFF
--- a/skydrop_configurator/app/res/desc.json
+++ b/skydrop_configurator/app/res/desc.json
@@ -534,7 +534,7 @@
 
                 ["WIDGET_COMPASS", "Compass"],
                 ["WIDGET_COMPASS_ARROW", "Compass arrow"],
-                ["WIDGET_COMPASS_HEADING", "Compas arrow text"],
+                ["WIDGET_COMPASS_POINTS", "Compass heading points"],
                 
                 ["WIDGET_BATTERY", "Battery status"],
                 ["WIDGET_TEMPERATURE", "Temperature and humidity"],
@@ -934,7 +934,7 @@
         "WIDGET_COMPASS_POINTS": 
         {
             "type": "value",
-            "name": "Compass heading",
+            "name": "Compass heading points",
             "desc": "Compas readout as points", 
             "label": "Comp",
             "value": "N"


### PR DESCRIPTION
When loading a CFG.EE that used a compass heading points widget the GUI showed "Unknown" because of a name inconsistency in the json description file:

![image](https://user-images.githubusercontent.com/670606/37203431-e3133318-238d-11e8-8887-c1040dae3083.png)
