### PR TITLE
Functionality to automatically cycle between the screens.

### DIFF
--- a/skydrop/src/fc/conf.h
+++ b/skydrop/src/fc/conf.h
@@ -28,6 +28,7 @@ struct cfg_gui_layout
 #define CFG_DISP_INVERT			0b00000001
 #define CFG_DISP_FLIP			0b00000010
 #define CFG_DISP_ANIM			0b00000100
+#define CFG_DISP_CYCLE			0b00001000               // Automatically cycle screens
 
 #define CFG_AUDIO_MENU_SPLASH	0b10000000
 #define CFG_AUDIO_MENU_PAGES	0b01000000

--- a/skydrop/src/gui/pages.cpp
+++ b/skydrop/src/gui/pages.cpp
@@ -26,6 +26,7 @@ uint8_t active_widget;
 
 #define PAGE_WIDGET_SELECT_DURATION	10
 #define PAGE_WIDGET_MENU_DURATION	15
+#define PAGE_CYCLE_DURATION			10
 
 #define PAGE_MENU_STEPS				5
 #define PAGE_MENU_WAIT				3000
@@ -42,6 +43,7 @@ uint8_t page_state;
 uint8_t page_state_step; //step based animation
 uint8_t page_state_dir;  //direction
 uint32_t page_state_timer; //timer based timeout
+uint32_t page_next_cycle_timer = 0;   // The time, when the next cycle should be done
 
 uint8_t page_change_dir;
 
@@ -149,6 +151,14 @@ void gui_pages_loop()
 		#ifdef FAKE_ENABLE
 			FAKE_DATA
 		#endif
+
+		if (config.gui.disp_flags & CFG_DISP_CYCLE) {
+			uint32_t now = task_get_ms_tick();
+			if ( now > page_next_cycle_timer ) {
+				page_next_cycle_timer = now + PAGE_CYCLE_DURATION * 1000;
+				page_switch(true);
+			}
+		}
 
 		widgets_draw(active_page);
 		gui_statusbar();

--- a/skydrop/src/gui/pages.h
+++ b/skydrop/src/gui/pages.h
@@ -18,6 +18,7 @@ void gui_pages_irqh(uint8_t type, uint8_t * buff);
 bool gui_enter_widget_menu();
 void gui_exit_widget_menu();
 void gui_page_power_off();
+void page_switch(bool right);
 
 extern uint8_t active_page;
 

--- a/skydrop/src/gui/settings/set_display.cpp
+++ b/skydrop/src/gui/settings/set_display.cpp
@@ -7,7 +7,7 @@
 
 void gui_set_display_init()
 {
-	gui_list_set(gui_set_display_item, gui_set_display_action, 6, GUI_SET_SYSTEM);
+	gui_list_set(gui_set_display_item, gui_set_display_action, 7, GUI_SET_SYSTEM);
 }
 
 void gui_set_display_stop() {}
@@ -87,7 +87,13 @@ void gui_set_display_action(uint8_t index)
 		eeprom_busy_wait();
 		eeprom_update_byte(&config_ee.gui.disp_flags, config.gui.disp_flags);
 	break;
-	}
+
+	case(6):
+		config.gui.disp_flags = config.gui.disp_flags ^ CFG_DISP_CYCLE;
+		eeprom_busy_wait();
+		eeprom_update_byte(&config_ee.gui.disp_flags, config.gui.disp_flags);
+	break;
+}
 }
 
 void gui_set_display_item(uint8_t index, char * text, uint8_t * flags, char * sub_text)
@@ -126,6 +132,13 @@ void gui_set_display_item(uint8_t index, char * text, uint8_t * flags, char * su
 		case (5):
 			strcpy_P(text, PSTR("Animation"));
 			if (config.gui.disp_flags & CFG_DISP_ANIM)
+				*flags |= GUI_LIST_CHECK_ON;
+			else
+				*flags |= GUI_LIST_CHECK_OFF;
+		break;
+		case (6):
+			strcpy_P(text, PSTR("Cycle"));
+			if (config.gui.disp_flags & CFG_DISP_CYCLE)
 				*flags |= GUI_LIST_CHECK_ON;
 			else
 				*flags |= GUI_LIST_CHECK_OFF;


### PR DESCRIPTION
To use this, turn on Menu>Settings>Display>Cycle.

Fixes https://github.com/fhorinek/SkyDrop/issues/328