### PR TITLE
Fix auto calibration for a already well adjusted vario value:

### DIFF
--- a/skydrop/src/fc/agl.cpp
+++ b/skydrop/src/fc/agl.cpp
@@ -325,7 +325,7 @@ void calibrate_alt()
 
 	float height_delta = best_height - fc.altitude1;
 
-	if ( abs(height_delta) > 10 ) {
+	if ( abs(height_delta) > 10 || height_min_error < fc.vario.error_over_time - 10) {
 		DEBUG("Calibrating altitude: now=%fm previous=%fm source=%d error=%fm\n", best_height, fc.altitude1, best_height_source, height_min_error);
 		sprintf_P(message, PSTR("QNH1 cal'ed:\n%0.0fm -> %0.0fm"), fc.altitude1, best_height);
 		gui_showmessage(message);


### PR DESCRIPTION
vario is already very well calibrated, when skydrop is turned on.
Then no calibration will be made, because height_delta < 10. So still,
the vario value will be associated with the (bad) error of 100 and will
only be corrected to a even worse GPS height, if the GPS height is so worse
that it is more than 10m away from vario. This use case is now fixed.