### PR TITLE
Add code for battery calibration.

### DIFF
--- a/skydrop/.cproject
+++ b/skydrop/.cproject
@@ -71,7 +71,7 @@
 									<listOptionValue builtIn="false" value="m"/>
 								</option>
 								<option id="de.innot.avreclipse.cpplinker.option.libpath.542621455" name="Libraries Path (-L)" superClass="de.innot.avreclipse.cpplinker.option.libpath" useByScannerDiscovery="false"/>
-								<option id="de.innot.avreclipse.cpplinker.option.otherlinkargs.852333318" name="Other Arguments" superClass="de.innot.avreclipse.cpplinker.option.otherlinkargs" useByScannerDiscovery="false" value="-Wl,-u,vfprintf -lm -Wl,--section-start=.fw_info=0x00810000 -Wl,--section-start=.eeprom=0x00810020 -Wl,--section-start=.cfg_ro=0x00810780" valueType="string"/>
+								<option id="de.innot.avreclipse.cpplinker.option.otherlinkargs.852333318" name="Other Arguments" superClass="de.innot.avreclipse.cpplinker.option.otherlinkargs" useByScannerDiscovery="false" value="-Wl,-u,vfprintf -lm -Wl,--section-start=.fw_info=0x00810000 -Wl,--section-start=.eeprom=0x00810020 -Wl,--section-start=.cfg_ro=0x00810680" valueType="string"/>
 								<option id="de.innot.avreclipse.cpplinker.option.nostart.1620358744" name="No startup or default libs (-nostdlib)" superClass="de.innot.avreclipse.cpplinker.option.nostart" useByScannerDiscovery="false" value="false" valueType="boolean"/>
 								<option id="de.innot.avreclipse.cpplinker.option.mrelax.1755937849" name="Relax branches (-mrelax)" superClass="de.innot.avreclipse.cpplinker.option.mrelax" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<inputType id="de.innot.avreclipse.tool.cpplinker.input.1462354175" name="OBJ Files" superClass="de.innot.avreclipse.tool.cpplinker.input">
@@ -204,7 +204,7 @@
 									<listOptionValue builtIn="false" value="m"/>
 								</option>
 								<option id="de.innot.avreclipse.cpplinker.option.libpath.1734561376" name="Libraries Path (-L)" superClass="de.innot.avreclipse.cpplinker.option.libpath"/>
-								<option id="de.innot.avreclipse.cpplinker.option.otherlinkargs.916590745" name="Other Arguments" superClass="de.innot.avreclipse.cpplinker.option.otherlinkargs" value="-Wl,-u,vfprintf -lm -Wl,--section-start=.fw_info=0x00810000 -Wl,--section-start=.eeprom=0x00810020 -Wl,--section-start=.cfg_ro=0x00810780" valueType="string"/>
+								<option id="de.innot.avreclipse.cpplinker.option.otherlinkargs.916590745" name="Other Arguments" superClass="de.innot.avreclipse.cpplinker.option.otherlinkargs" value="-Wl,-u,vfprintf -lm -Wl,--section-start=.fw_info=0x00810000 -Wl,--section-start=.eeprom=0x00810020 -Wl,--section-start=.cfg_ro=0x00810680" valueType="string"/>
 								<option id="de.innot.avreclipse.cpplinker.option.nostart.1554521088" name="No startup or default libs (-nostdlib)" superClass="de.innot.avreclipse.cpplinker.option.nostart" value="false" valueType="boolean"/>
 								<inputType id="de.innot.avreclipse.tool.cpplinker.input.346288255" name="OBJ Files" superClass="de.innot.avreclipse.tool.cpplinker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>

--- a/skydrop/src/drivers/battery.cpp
+++ b/skydrop/src/drivers/battery.cpp
@@ -1,6 +1,8 @@
 #include "battery.h"
 #include "../tasks/tasks.h"
 
+// #include "../debug_on.h"
+
 #define BATTERY_STATE_IDLE		0
 #define BATTERY_STATE_PREPARE	1
 #define BATTERY_STATE_START		2
@@ -28,7 +30,6 @@ uint16_t bat_adc_dif;
 #define BAT_CAL_INTERVAL 60                 // Interval in seconds to save calibration data
 
 #define BAT_CAL_FILE_RAW "/BAT-CAL.RAW"     // file to store raw calibration data collected during callibration
-#define BAT_CAL_FILE "/BAT-CAL.BIN"         // file to store 100 values corresponding to 0% - 100% after calibration
 
 /** This is the ADC value where the next lower percent value starts. */
 uint16_t bat_next_level = 0;
@@ -39,7 +40,7 @@ bool bat_cal_available = false;
 /**
  * This is a state machine for battery calibration:
  *
- * BATTERY_CAL_BOOT: System is booting, check for BAT_CAL_FILE_RAW and BAT_CAL_FILE and work with it.
+ * BATTERY_CAL_BOOT: System is booting, check for BAT_CAL_FILE_RAW and work with it.
  *                   Then go to BATTERY_CAL_NONE
  * BATTERY_CAL_NONE: No calibration is running, normal operation.
  * BATTERY_CAL_START: A battery calibration is starting. Inform user of what is going on. Then go to
@@ -49,66 +50,77 @@ bool bat_cal_available = false;
 uint8_t battery_calibrating_state = BATTERY_CAL_BOOT;
 
 /**
- * Read BAT_CAL_FILE and search for given "battery_adc_raw". Return corresponding percent value.
+ * Check, if we have calibration data for the battery in EEPROM.
+ *
+ * @return true if data is available, false otherwise.
+ */
+bool bat_calibrated()
+{
+	uint16_t value;
+
+	eeprom_busy_wait();
+	value = eeprom_read_word(&config_ro.bat_runtime_minutes);
+	DEBUG("config_ro.bat_runtime_minutes=%u\n", value);
+	return ( value != 0xffff );
+}
+
+/**
+ * Read EEPROM and search for given "battery_adc_raw". Return corresponding percent value.
  * It also sets "bat_next_level" for the next lower level.
  *
  * @param battery_adc_raw the ADC value to search for
  *
  * @return the corresponding percent value or 101 for error.
  */
-uint8_t read_battery_per_from_calibration(uint16_t battery_adc_raw) {
-	FIL cal_file;
-	uint16_t wt;
-	uint8_t res;
+uint8_t read_battery_per_from_calibration(uint16_t battery_adc_raw)
+{
 	uint8_t percent;
 	uint16_t battery;
 
 	bat_next_level = 0;
 
-	res = f_open(&cal_file, BAT_CAL_FILE, FA_READ);
-	if (res != FR_OK)
-		return 101;
+	if ( !bat_calibrated() )
+		return 101;                  // No calibration available
 
-	for (percent = 100; percent >= 0; percent-- ) {
-		res = f_read(&cal_file, &battery, sizeof(battery), &wt);
-		if ( res == FR_OK && wt == sizeof(battery) ) {
-			if ( battery_adc_raw > battery ) {
-				bat_next_level = battery;
-				break;
-			}
-		} else {
+	for (percent = 100; percent > 0; percent-- )
+	{
+		eeprom_busy_wait();
+		battery = eeprom_read_word(&config_ro.bat_calibration[100-percent]);
+		if ( battery_adc_raw > battery )
+		{
+			bat_next_level = battery;
 			break;
 		}
 	}
-
-	f_close(&cal_file);
 
 	return percent;
 }
 
 /**
  * Get corresponding percent value for given "battery_adc_raw". This will use "bat_next_value" to
- * only read file BAT_CAL_FILE is necessary.
+ * only read EEPROM if necessary.
  *
  * @param battery_adc_raw the ADC value to search for
  *
  * @return the corresponding percent value or 101 for error
  */
-int8_t get_battery_per_from_calibration(uint16_t battery_adc_raw) {
+int8_t get_battery_per_from_calibration(uint16_t battery_adc_raw)
+{
 	uint8_t percent;
 
 	/* Check, if we have a calibration available: */
-	if ( bat_cal_available ) {
-
+	if ( bat_cal_available )
+	{
 		/* Check, if we reached the next level. If not return identical percent */
-		if ( bat_next_level != 0 && battery_adc_raw > bat_next_level ) {
+		if ( bat_next_level != 0 && battery_adc_raw > bat_next_level )
 			return battery_per;
-		}
 
 		percent = read_battery_per_from_calibration(battery_adc_raw);
 		DEBUG("get_battery_per_from_calibration(%d)=%d ", battery_adc_raw, percent);
 		print_datetime(time_get_local());
-	} else {
+	}
+	else
+	{
 		percent = 101;
 	}
 
@@ -196,75 +208,75 @@ void save_bat_cal_value(uint16_t battery_adc_raw)
 }
 
 /**
- * This function reads calibration from BAT_CAL_FILE_RAW and creates a BAT_CAL_FILE used during normal
+ * This function reads calibration from BAT_CAL_FILE_RAW and creates EEPROM used during normal
  * operations. To do it creates 100 values which correspond to 100% until 0%. Each value is computed by using
  * the average to multiple available ADC values.
  */
 void resort_bat_cal()
 {
 	uint8_t res;
-	FIL cal_file;
 	FIL cal_file_raw;
 	uint16_t wt;
 	uint16_t battery;
 	bool error = false;
-	int num;
+	uint16_t num;
 
 	res = f_open(&cal_file_raw, BAT_CAL_FILE_RAW, FA_READ);
 	if (res != FR_OK)
 		return;
-	res = f_open(&cal_file, BAT_CAL_FILE, FA_WRITE | FA_OPEN_ALWAYS);
-	if (res != FR_OK) {
-		f_close(&cal_file_raw);
-		return;
-	}
 
 	DEBUG("resort_bat_cal: f_size(raw): %ld\n", f_size(&cal_file_raw));
 	/* This can be saved in eeprom to store the number of minutes, the battery lasts. */
 	num = f_size(&cal_file_raw) / sizeof(uint16_t);
 
-	for ( int i = 0; i < 100; i++ ) {
+	for ( int i = 0; i < 100; i++ )
+	{
 		int32_t start = (int32_t)num * i / 100;
 		res = f_lseek(&cal_file_raw, (DWORD)start * sizeof(uint16_t));
-		if (res != FR_OK) {
+		if (res != FR_OK)
+		{
 			DEBUG("resort_bat_cal: f_lseek failed\n");
 			break;
 		}
 		int32_t sum = 0;
 		int16_t num_values = 0;
-		for (unsigned int j = 0; j < f_size(&cal_file_raw) / 100; j++ ) {
+		for (unsigned int j = 0; j < f_size(&cal_file_raw) / 100; j++ )
+		{
 			res = f_read(&cal_file_raw, &battery, sizeof(battery), &wt);
-			if ( res == FR_OK && wt == sizeof(battery) ) {
+			if ( res == FR_OK && wt == sizeof(battery) )
+			{
 				sum += battery;
 				num_values++;
 				// DEBUG("Battery cal: num_values=%d, sum=%ld\n", num_values, sum);
 			}
 		}
-        	if ( num_values == 0 ) {
+		if ( num_values == 0 )
+		{
 			error = true;
 			break;
 		}
 		battery = sum / num_values;
 
-		// DEBUG("Battery resort_bat_cal: write=%d\n", battery);
-		res = f_write(&cal_file, &battery, sizeof(battery), &wt);
-		if ( res != FR_OK || wt != sizeof(battery) ) {
-			DEBUG("resort_bat_cal: Unable to write\n");
-			error = true;
-			break;
-		}
+		DEBUG("Battery resort_bat_cal: bat_calibration[%d]=%u\n", i, battery);
+		eeprom_busy_wait();
+		eeprom_write_word(&config_ro.bat_calibration[i], battery);
 	}
 
-	f_close(&cal_file);
+	eeprom_busy_wait();
+	eeprom_write_word(&config_ro.bat_runtime_minutes, num);
+
 	f_close(&cal_file_raw);
 
 	DEBUG("resort_bat_cal error: %d\n", (int)error);
 
-	if ( !error) {
+	if ( !error)
+	{
 		f_unlink(BAT_CAL_FILE_RAW);
-        	gui_showmessage_P(PSTR("Battery Cal:\nFinished."));
-	} else {
-        	gui_showmessage_P(PSTR("Battery Cal:\nError!\nPlease retry."));
+        gui_showmessage_P(PSTR("Battery Cal:\nFinished."));
+	}
+	else
+	{
+        gui_showmessage_P(PSTR("Battery Cal:\nError!\nPlease retry."));
 	}
 }
 
@@ -278,6 +290,7 @@ void battery_cal()
 	static uint32_t battery_calibrating_next_message = 0;
 	static uint32_t battery_calibrating_next_cal = 0;
 	FILINFO fno;
+
 #define BAT_CAL_MESSAGE_DURATION 5
 
 	switch (battery_calibrating_state)
@@ -285,12 +298,11 @@ void battery_cal()
 	case BATTERY_CAL_BOOT:
 		if (!storage_ready() || gui_task != GUI_PAGES)
 			break;                 // wait for system to operate normally
-		if (f_stat(BAT_CAL_FILE_RAW, &fno) == FR_OK) {
+		if (f_stat(BAT_CAL_FILE_RAW, &fno) == FR_OK)
 			resort_bat_cal();      // check, if calibration raw is available
-		}
-		if (f_stat(BAT_CAL_FILE, &fno) == FR_OK) {
+		if ( bat_calibrated() )
 			bat_cal_available = true;
-		}
+
 		battery_calibrating_state = BATTERY_CAL_NONE;
 		break;
 	case BATTERY_CAL_NONE:
@@ -317,14 +329,18 @@ void battery_cal()
 			break;
 		default:
 			// We are discharging, which is wrong here. We first want to charge until BATTERY_FULL
-			if ( task_get_ms_tick() > battery_calibrating_next_message) {
+			if ( task_get_ms_tick() > battery_calibrating_next_message)
+			{
 				battery_calibrating_next_message = task_get_ms_tick() + BAT_CAL_REMIND_INTERVAL * 1000L;
 				charge_counter++;
-				if ( charge_counter >= 4 ) {
+				if ( charge_counter >= 4 )
+				{
 					gui_showmessage_P(PSTR("Battery Cal:\nCharge missing.\nNow discharge."));
 					battery_calibrating_state = BATTERY_CAL_DISCHARGE;
 					DEBUG("Battery Cal.\nunplugged...\n");
-				} else {
+				}
+				else
+				{
 					DEBUG("Battery Cal.\nPlease charge!\n");
 					gui_showmessage_P(PSTR("Battery Cal:\nPlease charge!"));
 				}
@@ -344,14 +360,16 @@ void battery_cal()
 		case BATTERY_FULL:
 			battery_calibrating_next_cal = 0;
 			f_unlink(BAT_CAL_FILE_RAW);
-			if ( task_get_ms_tick() > battery_calibrating_next_message) {
+			if ( task_get_ms_tick() > battery_calibrating_next_message)
+			{
 				battery_calibrating_next_message = task_get_ms_tick() + BAT_CAL_REMIND_INTERVAL * 1000L;
 				gui_showmessage_P(PSTR("Battery Cal.\nPlease\ndischarge!"));
 				DEBUG("Battery Cal.\nPlease discharge!");
 			}
 			break;
 		default:
-			if ( task_get_ms_tick() > battery_calibrating_next_cal) {
+			if ( task_get_ms_tick() > battery_calibrating_next_cal)
+			{
 				battery_calibrating_next_cal = task_get_ms_tick() + BAT_CAL_INTERVAL * 1000L;
 				save_bat_cal_value(battery_adc_raw);
 			}
@@ -435,7 +453,8 @@ bool battery_step()
 
 		battery_per = get_battery_per_from_calibration(battery_adc_raw);
 
-		if ( battery_per > 100 ) {
+		if ( battery_per > 100 )
+		{
 			//5% is planned overshoot
 			battery_per = (((int32_t)battery_adc_raw - (int32_t)BAT_ADC_MIN) * 105) / bat_adc_dif;
 		}

--- a/skydrop/src/drivers/battery.cpp
+++ b/skydrop/src/drivers/battery.cpp
@@ -24,6 +24,97 @@ int8_t battery_per = 0;
 uint16_t bat_adc_max;
 uint16_t bat_adc_dif;
 
+#define BAT_CAL_REMIND_INTERVAL 10          // Interval in seconds to remind user of wrong charging/discharging
+#define BAT_CAL_INTERVAL 60                 // Interval in seconds to save calibration data
+
+#define BAT_CAL_FILE_RAW "/BAT-CAL.RAW"     // file to store raw calibration data collected during callibration
+#define BAT_CAL_FILE "/BAT-CAL.BIN"         // file to store 100 values corresponding to 0% - 100% after calibration
+
+/** This is the ADC value where the next lower percent value starts. */
+uint16_t bat_next_level = 0;
+
+/** Do we have calibration data during normal operation. */
+bool bat_cal_available = false;
+
+/**
+ * This is a state machine for battery calibration:
+ *
+ * BATTERY_CAL_BOOT: System is booting, check for BAT_CAL_FILE_RAW and BAT_CAL_FILE and work with it.
+ *                   Then go to BATTERY_CAL_NONE
+ * BATTERY_CAL_NONE: No calibration is running, normal operation.
+ * BATTERY_CAL_START: A battery calibration is starting. Inform user of what is going on. Then go to
+ * BATTERY_CAL_CHARGE: wait until battery is fully charged.
+ * BATTERY_CAL_DISCHARGE: wait until battery is fully discharged, store calibration data every BAT_CAL_INTERVAL.
+ */
+uint8_t battery_calibrating_state = BATTERY_CAL_BOOT;
+
+/**
+ * Read BAT_CAL_FILE and search for given "battery_adc_raw". Return corresponding percent value.
+ * It also sets "bat_next_level" for the next lower level.
+ *
+ * @param battery_adc_raw the ADC value to search for
+ *
+ * @return the corresponding percent value or 101 for error.
+ */
+uint8_t read_battery_per_from_calibration(uint16_t battery_adc_raw) {
+	FIL cal_file;
+	uint16_t wt;
+	uint8_t res;
+	uint8_t percent;
+	uint16_t battery;
+
+	bat_next_level = 0;
+
+	res = f_open(&cal_file, BAT_CAL_FILE, FA_READ);
+	if (res != FR_OK)
+		return 101;
+
+	for (percent = 100; percent >= 0; percent-- ) {
+		res = f_read(&cal_file, &battery, sizeof(battery), &wt);
+		if ( res == FR_OK && wt == sizeof(battery) ) {
+			if ( battery_adc_raw > battery ) {
+				bat_next_level = battery;
+				break;
+			}
+		} else {
+			break;
+		}
+	}
+
+	f_close(&cal_file);
+
+	return percent;
+}
+
+/**
+ * Get corresponding percent value for given "battery_adc_raw". This will use "bat_next_value" to
+ * only read file BAT_CAL_FILE is necessary.
+ *
+ * @param battery_adc_raw the ADC value to search for
+ *
+ * @return the corresponding percent value or 101 for error
+ */
+int8_t get_battery_per_from_calibration(uint16_t battery_adc_raw) {
+	uint8_t percent;
+
+	/* Check, if we have a calibration available: */
+	if ( bat_cal_available ) {
+
+		/* Check, if we reached the next level. If not return identical percent */
+		if ( bat_next_level != 0 && battery_adc_raw > bat_next_level ) {
+			return battery_per;
+		}
+
+		percent = read_battery_per_from_calibration(battery_adc_raw);
+		DEBUG("get_battery_per_from_calibration(%d)=%d ", battery_adc_raw, percent);
+		print_datetime(time_get_local());
+	} else {
+		percent = 101;
+	}
+
+	return percent;
+}
+
 void battery_reset_calibration()
 {
 	if (bat_adc_max == BAT_ADC_MIN)
@@ -71,17 +162,227 @@ void battery_force_update()
 
 uint16_t bat_charge_discharge_ratio = 0;
 
+/**
+ * Save the given ADC value into BAT_CAL_FILE_RAW.
+ *
+ * @param battery_adc_raw the value to append at the end of the file.
+ */
+void save_bat_cal_value(uint16_t battery_adc_raw)
+{
+	uint8_t res;
+	FIL cal_file;
+	uint16_t wt;
+
+	if (!storage_ready())
+		return;
+
+	// open or create new
+	res = f_open(&cal_file, BAT_CAL_FILE_RAW, FA_WRITE | FA_OPEN_ALWAYS);
+	if (res != FR_OK)
+		return;
+
+	//seek to end
+	res = f_lseek(&cal_file, f_size(&cal_file));
+	if (res != FR_OK)
+	{
+		f_close(&cal_file);
+		return;
+	}
+
+	f_write(&cal_file, &battery_adc_raw, sizeof(battery_adc_raw), &wt);
+	f_close(&cal_file);
+
+	DEBUG("Battery cal: wrote %d\n", battery_adc_raw);
+}
+
+/**
+ * This function reads calibration from BAT_CAL_FILE_RAW and creates a BAT_CAL_FILE used during normal
+ * operations. To do it creates 100 values which correspond to 100% until 0%. Each value is computed by using
+ * the average to multiple available ADC values.
+ */
+void resort_bat_cal()
+{
+	uint8_t res;
+	FIL cal_file;
+	FIL cal_file_raw;
+	uint16_t wt;
+	uint16_t battery;
+	bool error = false;
+	int num;
+
+	res = f_open(&cal_file_raw, BAT_CAL_FILE_RAW, FA_READ);
+	if (res != FR_OK)
+		return;
+	res = f_open(&cal_file, BAT_CAL_FILE, FA_WRITE | FA_OPEN_ALWAYS);
+	if (res != FR_OK) {
+		f_close(&cal_file_raw);
+		return;
+	}
+
+	DEBUG("resort_bat_cal: f_size(raw): %ld\n", f_size(&cal_file_raw));
+	/* This can be saved in eeprom to store the number of minutes, the battery lasts. */
+	num = f_size(&cal_file_raw) / sizeof(uint16_t);
+
+	for ( int i = 0; i < 100; i++ ) {
+		int32_t start = (int32_t)num * i / 100;
+		res = f_lseek(&cal_file_raw, (DWORD)start * sizeof(uint16_t));
+		if (res != FR_OK) {
+			DEBUG("resort_bat_cal: f_lseek failed\n");
+			break;
+		}
+		int32_t sum = 0;
+		int16_t num_values = 0;
+		for (unsigned int j = 0; j < f_size(&cal_file_raw) / 100; j++ ) {
+			res = f_read(&cal_file_raw, &battery, sizeof(battery), &wt);
+			if ( res == FR_OK && wt == sizeof(battery) ) {
+				sum += battery;
+				num_values++;
+				// DEBUG("Battery cal: num_values=%d, sum=%ld\n", num_values, sum);
+			}
+		}
+        	if ( num_values == 0 ) {
+			error = true;
+			break;
+		}
+		battery = sum / num_values;
+
+		// DEBUG("Battery resort_bat_cal: write=%d\n", battery);
+		res = f_write(&cal_file, &battery, sizeof(battery), &wt);
+		if ( res != FR_OK || wt != sizeof(battery) ) {
+			DEBUG("resort_bat_cal: Unable to write\n");
+			error = true;
+			break;
+		}
+	}
+
+	f_close(&cal_file);
+	f_close(&cal_file_raw);
+
+	DEBUG("resort_bat_cal error: %d\n", (int)error);
+
+	if ( !error) {
+		f_unlink(BAT_CAL_FILE_RAW);
+        	gui_showmessage_P(PSTR("Battery Cal:\nFinished."));
+	} else {
+        	gui_showmessage_P(PSTR("Battery Cal:\nError!\nPlease retry."));
+	}
+}
+
+/**
+ * This is the main function for battery calibration. If uses battery_calibrating_state to keep
+ * track of where the operation is.
+ */
+void battery_cal()
+{
+	static uint8_t charge_counter = 0;
+	static uint32_t battery_calibrating_next_message = 0;
+	static uint32_t battery_calibrating_next_cal = 0;
+	FILINFO fno;
+#define BAT_CAL_MESSAGE_DURATION 5
+
+	switch (battery_calibrating_state)
+	{
+	case BATTERY_CAL_BOOT:
+		if (!storage_ready() || gui_task != GUI_PAGES)
+			break;                 // wait for system to operate normally
+		if (f_stat(BAT_CAL_FILE_RAW, &fno) == FR_OK) {
+			resort_bat_cal();      // check, if calibration raw is available
+		}
+		if (f_stat(BAT_CAL_FILE, &fno) == FR_OK) {
+			bat_cal_available = true;
+		}
+		battery_calibrating_state = BATTERY_CAL_NONE;
+		break;
+	case BATTERY_CAL_NONE:
+		break;
+
+	case BATTERY_CAL_START:
+		DEBUG("Battery Cal: Start\n");
+		charge_counter = 0;
+		gui_showmessage_P(PSTR("Battery Cal:\nCharge to full,\nthen discharge."));
+		gui_messageduration(BAT_CAL_MESSAGE_DURATION);
+		battery_calibrating_next_message = task_get_ms_tick() + BAT_CAL_MESSAGE_DURATION * 1000L;
+		battery_calibrating_state = BATTERY_CAL_CHARGE;
+		break;
+
+	case BATTERY_CAL_CHARGE:
+		switch (battery_per) {
+		case ( BATTERY_FULL ):
+			// Battery is now full, go to DISCHARGE state
+			battery_calibrating_state = BATTERY_CAL_DISCHARGE;
+			DEBUG("Battery Cal: BATTERY FULL.\n");
+			break;
+		case BATTERY_CHARGING:
+			charge_counter = 0;
+			break;
+		default:
+			// We are discharging, which is wrong here. We first want to charge until BATTERY_FULL
+			if ( task_get_ms_tick() > battery_calibrating_next_message) {
+				battery_calibrating_next_message = task_get_ms_tick() + BAT_CAL_REMIND_INTERVAL * 1000L;
+				charge_counter++;
+				if ( charge_counter >= 4 ) {
+					gui_showmessage_P(PSTR("Battery Cal:\nCharge missing.\nNow discharge."));
+					battery_calibrating_state = BATTERY_CAL_DISCHARGE;
+					DEBUG("Battery Cal.\nunplugged...\n");
+				} else {
+					DEBUG("Battery Cal.\nPlease charge!\n");
+					gui_showmessage_P(PSTR("Battery Cal:\nPlease charge!"));
+				}
+			}
+			break;
+		}
+		break;
+
+	case BATTERY_CAL_DISCHARGE:
+		switch (battery_per) {
+		case (BATTERY_CHARGING):
+			// BAD: The user has plugged in charging in the middle of the discharge. Go back to full charge.
+			f_unlink(BAT_CAL_FILE_RAW);
+			battery_calibrating_state = BATTERY_CAL_CHARGE;
+			DEBUG("Battery cal: recharged.\n");
+			break;
+		case BATTERY_FULL:
+			battery_calibrating_next_cal = 0;
+			f_unlink(BAT_CAL_FILE_RAW);
+			if ( task_get_ms_tick() > battery_calibrating_next_message) {
+				battery_calibrating_next_message = task_get_ms_tick() + BAT_CAL_REMIND_INTERVAL * 1000L;
+				gui_showmessage_P(PSTR("Battery Cal.\nPlease\ndischarge!"));
+				DEBUG("Battery Cal.\nPlease discharge!");
+			}
+			break;
+		default:
+			if ( task_get_ms_tick() > battery_calibrating_next_cal) {
+				battery_calibrating_next_cal = task_get_ms_tick() + BAT_CAL_INTERVAL * 1000L;
+				save_bat_cal_value(battery_adc_raw);
+			}
+			break;
+		}
+		break;
+	case BATTERY_CAL_STOP:
+		f_unlink(BAT_CAL_FILE_RAW);
+		battery_calibrating_state = BATTERY_CAL_NONE;
+		gui_showmessage_P(PSTR("Battery Cal.\nAborted."));
+		DEBUG("Battery Cal.\nAborted!");
+		break;
+	}
+}
+
 bool battery_step()
 {
 	#ifdef FAKE_ENABLE
 		return false;
 	#endif
 
+	battery_cal();
+
 	if (battery_next_meas > task_get_ms_tick())
 		return false;
 
 	if (USB_CONNECTED)
 	{
+		/* As we are charging, the bat_next_level is not valid anymore */
+		bat_next_level = 0;
+
 		if (BAT_CHARGING)
 		{
 			if (bat_charge_discharge_ratio > 1)
@@ -132,8 +433,12 @@ bool battery_step()
 			eeprom_update_word(&config_ro.bat_adc_max, bat_adc_max);
 		}
 
-		//5% is planned overshoot
-		battery_per = (((int32_t)battery_adc_raw - (int32_t)BAT_ADC_MIN) * 105) / bat_adc_dif;
+		battery_per = get_battery_per_from_calibration(battery_adc_raw);
+
+		if ( battery_per > 100 ) {
+			//5% is planned overshoot
+			battery_per = (((int32_t)battery_adc_raw - (int32_t)BAT_ADC_MIN) * 105) / bat_adc_dif;
+		}
 		if (battery_per > 100)
 			battery_per = 100;
 		if (battery_per < 0)

--- a/skydrop/src/drivers/battery.h
+++ b/skydrop/src/drivers/battery.h
@@ -17,8 +17,17 @@ extern uint32_t battery_next_meas;
 
 extern uint16_t bat_adc_max;
 
+extern uint8_t battery_calibrating_state;
+
 #define BATTERY_CHARGING	(101)
 #define BATTERY_FULL		(102)
+
+#define BATTERY_CAL_NONE      (0)
+#define BATTERY_CAL_BOOT      (1)
+#define BATTERY_CAL_START     (2)
+#define BATTERY_CAL_CHARGE    (3)
+#define BATTERY_CAL_DISCHARGE (4)
+#define BATTERY_CAL_STOP      (5)
 
 void battery_init();
 bool battery_step();

--- a/skydrop/src/fc/conf.cpp
+++ b/skydrop/src/fc/conf.cpp
@@ -366,6 +366,14 @@ void cfg_baro_write_defaults()
 	eeprom_update_block(&tmp, &config_ro.baro_offset, sizeof(config_ro.baro_offset));
 }
 
+void cfg_bat_write_defaults()
+{
+	uint16_t tmp = 0xffff;
+	eeprom_busy_wait();
+	eeprom_write_word(&config_ro.bat_runtime_minutes, tmp);
+}
+
+
 void cfg_check_floats()
 {
 	if (isnan(config.altitude.QNH1))
@@ -410,6 +418,7 @@ void cfg_load()
 		cfg_gyro_write_defaults();
 		cfg_compass_write_defaults();
 		cfg_baro_write_defaults();
+		cfg_bat_write_defaults();
 
 		eeprom_busy_wait();
 		eeprom_update_byte(&config_ro.calibration_flags, CALIB_DEFAULT_LOADED);

--- a/skydrop/src/fc/conf.h
+++ b/skydrop/src/fc/conf.h
@@ -289,39 +289,47 @@ struct debug_info
 
 //DO NOT CHANGE THE ORDER, add new value at the end
 //Device config not related to user settings
+//
+//This data is accessible by using eeprom_read_byte/eeprom_update_byte...
+//
 //						dec		hex
-//size 					128		0x80
-//start address			1920	0x780
+//size 					384		0x180
+//start address			1920	0x680
 struct cfg_ro_t
 {									//offset	size
-	uint8_t factory_passed;			//+0		1
-	uint8_t lcd_contrast_min;		//+1		1
-	uint8_t lcd_contrast_max;		//+2		1
+	uint8_t reserved0[54];          //+0        54
 
-	uint8_t bt_module_type; 		//+3		1
+	uint16_t bat_runtime_minutes;   //+54       2    How many minutes does the battery run if full? 0xffff=no calib done
+	uint16_t bat_calibration[100];  //+56       200
 
-	cfg_calibration calibration;	//+4		24
+	uint8_t factory_passed;			//+256		1
+	uint8_t lcd_contrast_min;		//+257		1
+	uint8_t lcd_contrast_max;		//+258		1
 
-	uint8_t hw_revision;			//+28		1
+	uint8_t bt_module_type; 		//+259		1
 
-	uint8_t flight_number;			//+29		1
-	uint32_t flight_date;			//+30		4
+	cfg_calibration calibration;	//+260		24
 
-	debug_info debug;				//+34		14
+	uint8_t hw_revision;			//+284		1
 
-	uint16_t bat_adc_max;			//+48		2
+	uint8_t flight_number;			//+285		1
+	uint32_t flight_date;			//+286		4
 
-	uint8_t calibration_flags;		//+50		1
+	debug_info debug;				//+290		14
 
-	vector_i16_t gyro_bias;			//+51		6
+	uint16_t bat_adc_max;			//+304		2
 
-	int16_t	magnetic_declination;	//+57		2
+	uint8_t calibration_flags;		//+306		1
 
-	uint32_t total_flight_time;		//+59		4
+	vector_i16_t gyro_bias;			//+307		6
 
-	int16_t baro_offset;			//+61		2
+	int16_t	magnetic_declination;	//+313		2
 
-	uint8_t reserved[70];			//+63		62
+	uint32_t total_flight_time;		//+315		4
+
+	int16_t baro_offset;			//+319		2
+
+	uint8_t reserved[70];			//+321		62
 };
 
 //configuration in RAM

--- a/skydrop/src/gui/gui.cpp
+++ b/skydrop/src/gui/gui.cpp
@@ -486,7 +486,7 @@ void gui_loop()
 		if (gui_task == GUI_PAGES)
 		{
 			//Power off if not in flight, auto power off is enabled and bluetooth device is not connected
-			if (fc.flight.state != FLIGHT_FLIGHT && config.system.auto_power_off > 0 && !bt_device_active())
+			if (fc.flight.state != FLIGHT_FLIGHT && config.system.auto_power_off > 0 && !bt_device_active() && battery_calibrating_state == BATTERY_CAL_NONE)
 			{
 				if (task_get_ms_tick() - gui_idle_timer > (uint32_t)config.system.auto_power_off * 60ul * 1000ul)
 				{
@@ -732,17 +732,30 @@ void gui_statusbar()
 		}
 
 	//battery indicator
-	uint8_t a = battery_per / 10;
-
-	if (battery_per == BATTERY_CHARGING)
-	{
-		a = 1 + (task_get_ms_tick() % 2000) / 200;
-	}
-
-	if (battery_per == BATTERY_FULL)
-		a = 10;
-
 	disp.DrawLine(GUI_DISP_WIDTH - 5, GUI_DISP_HEIGHT - 13, GUI_DISP_WIDTH - 2, GUI_DISP_HEIGHT - 13, 1);
 	disp.DrawRectangle(GUI_DISP_WIDTH - 6, GUI_DISP_HEIGHT - 12, GUI_DISP_WIDTH - 1, GUI_DISP_HEIGHT - 1, 1, 0);
-	disp.DrawRectangle(GUI_DISP_WIDTH - 5, GUI_DISP_HEIGHT - 1 - a, GUI_DISP_WIDTH - 2, GUI_DISP_HEIGHT - 1, 1, 1);
+
+	if ( battery_calibrating_state == BATTERY_CAL_NONE) {
+		uint8_t a = battery_per / 10;
+
+		if (battery_per == BATTERY_CHARGING)
+		{
+			a = 1 + (task_get_ms_tick() % 2000) / 200;
+		}
+
+		if (battery_per == BATTERY_FULL)
+			a = 10;
+		disp.DrawRectangle(GUI_DISP_WIDTH - 5, GUI_DISP_HEIGHT - 1 - a, GUI_DISP_WIDTH - 2, GUI_DISP_HEIGHT - 1, 1, 1);
+	} else {
+		uint8_t a;
+		uint8_t x1, x2;
+
+		a = (task_get_ms_tick() % 2000) / 250;
+		if ( battery_calibrating_state == BATTERY_CAL_DISCHARGE ) a = 7 - a;
+		x1 = GUI_DISP_WIDTH - 2 - a;
+		x2 = x1 + 3;
+		x1 = max(GUI_DISP_WIDTH - 6, x1);
+		x2 = min(GUI_DISP_WIDTH - 2, x2);
+		disp.DrawRectangle(x1, GUI_DISP_HEIGHT - 12, x2, GUI_DISP_HEIGHT - 2, 1, 1);
+	}
 }

--- a/skydrop/src/gui/settings/set_calib.cpp
+++ b/skydrop/src/gui/settings/set_calib.cpp
@@ -8,11 +8,11 @@
 #include "set_calib.h"
 #include "../gui_list.h"
 #include "../gui_dialog.h"
-
+#include "../../drivers/battery.h"
 
 void gui_set_calib_init()
 {
-	gui_list_set(gui_set_calib_item, gui_set_calib_action, 4, GUI_SET_ADVANCED);
+	gui_list_set(gui_set_calib_item, gui_set_calib_action, 5, GUI_SET_ADVANCED);
 }
 
 void gui_set_calib_stop() {}
@@ -65,6 +65,13 @@ void gui_set_calib_action(uint8_t index)
 	case(3):
 		gui_switch_task(GUI_SET_COMPASS);
 	break;
+
+	case(4):
+		if (battery_calibrating_state == BATTERY_CAL_NONE)
+			battery_calibrating_state = BATTERY_CAL_START;
+		else
+			battery_calibrating_state = BATTERY_CAL_STOP;
+	break;
 	}
 }
 
@@ -90,6 +97,15 @@ void gui_set_calib_item(uint8_t index, char * text, uint8_t * flags, char * sub_
 		case (3):
 			strcpy_P(text, PSTR("Compass"));
 			*flags |= GUI_LIST_FOLDER;
+		break;
+
+		case (4):
+			strcpy_P(text, PSTR("Battery"));
+			if (battery_calibrating_state != BATTERY_CAL_NONE)
+				*flags |= GUI_LIST_CHECK_ON;
+			else
+				*flags |= GUI_LIST_CHECK_OFF;
+
 		break;
 	}
 }

--- a/skydrop/utils/calib/bat-cal-to-csv.py
+++ b/skydrop/utils/calib/bat-cal-to-csv.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+#
+# This file reads a BAT-CAL.RAW file and prints the content to stdout
+# as a CSV file. This can be used to draw a diagram of the battery
+# discharge.
+#
+# usage:
+#   % python3 bat-cal-to-csv.py BAT-CAL.RAW > bat.csv
+#   % ooffice bat.csv 
+#
+# 2019-08-03: tilmann@bubecks.de
+#
+
+import sys
+
+def usage():
+    print("bat-cal-to-csv.py BAT-CAL.RAW\n")
+    
+if len(sys.argv) != 2:
+    usage()
+    sys.exit(1)
+
+f = open(sys.argv[1], "rb")
+while True:
+    chunk = f.read(2)
+    if len(chunk) == 0:
+        break
+    val = int.from_bytes(chunk, 'little', signed=False)
+    print(val)
+    


### PR DESCRIPTION
New menu item "Settings>Advanced>Calibration>Battery". Choosing this will
start a calibration. The user has to fully charge the battery, and then
remove power, so that the battery will be discharged completely. During
discharge, the current ADC value will be saved periodically. After turning
on power, this file will be converted to a more compact form (averaging
the values for 0-100%) and then used during normal operation.

This results in a much better percentage and therefore allows the user
to better know how long the device lasts.

Fixes https://github.com/fhorinek/SkyDrop/issues/340