### PR TITLE
Count, store and show distance of a flight (odometer).

### DIFF
--- a/skydrop/src/fc/fc.cpp
+++ b/skydrop/src/fc/fc.cpp
@@ -456,6 +456,7 @@ void fc_takeoff()
 	//reset timer and altitude for autoland
 	fc.flight.autostart_altitude = fc.altitude1;
 	fc.flight.autostart_timer = task_get_ms_tick();
+	fc.flight.autostart_odo = fc.odometer;
 
 	//set start position
 	if (fc.gps_data.valid)
@@ -513,6 +514,7 @@ void fc_landing()
 	logger_comment(PSTR(" SKYDROP-ALT-MIN-m: %d "), fc.flight.stats.min_alt);
 	logger_comment(PSTR(" SKYDROP-CLIMB-MAX-cm: %d "), fc.flight.stats.max_climb);
 	logger_comment(PSTR(" SKYDROP-SINK-MAX-cm: %d "), fc.flight.stats.max_sink);
+	logger_comment(PSTR(" SKYDROP-ODO-cm: %lu "), fc.odometer - fc.flight.autostart_odo);
 
 	logger_stop();
 }

--- a/skydrop/src/fc/fc.h
+++ b/skydrop/src/fc/fc.h
@@ -233,6 +233,8 @@ struct flight_data_t
 
 	uint32_t total_time; //in seconds
 
+	uint32_t autostart_odo;   // odometer at start time.
+
   //waypoints
 	int waypoint_no;                 // The number of the next waypoint where we need to fly. The first waypoint is "1".
 	int waypoints_count;			 // The number of waypoints in the file.

--- a/skydrop/src/gui/settings/gui_flightdetail.cpp
+++ b/skydrop/src/gui/settings/gui_flightdetail.cpp
@@ -14,6 +14,7 @@
 #include "../../fc/logger/logger.h"
 
 uint32_t log_duration;
+uint32_t log_odo;
 uint32_t log_start;
 struct flight_stats_t log_stat;
 
@@ -63,6 +64,7 @@ void gui_flightdetail_parse_logfile(const char *filename)
 	log_stat.min_alt = LOG_NODATA_i16;
 	log_stat.max_climb = LOG_NODATA_i16;
 	log_stat.max_sink = LOG_NODATA_i16;
+	log_odo = LOG_NODATA_u32;
 
 	DEBUG("parse_logfile(%s)\n", filename);
 
@@ -110,6 +112,12 @@ void gui_flightdetail_parse_logfile(const char *filename)
 			log_stat.max_sink = atoi(p + 21);
 			continue;
 		}
+
+		p = strstr_P(line, PSTR("SKYDROP-ODO-cm: "));
+		if ( p != NULL ) {
+			log_odo = atol(p + 16);
+			continue;
+		}
 	}
 
 	DEBUG("closing log file\n");
@@ -123,7 +131,7 @@ void gui_flightdetail_init()
 	sprintf_P(tmp, PSTR("%s/%s"), gui_filemanager_path, gui_filemanager_name);
 	gui_flightdetail_parse_logfile(tmp);
 
-	gui_list_set(gui_flightdetail_item, gui_flightdetail_action, 7, GUI_FILEMANAGER);
+	gui_list_set(gui_flightdetail_item, gui_flightdetail_action, 8, GUI_FILEMANAGER);
 }
 
 void gui_flightdetail_stop() {}
@@ -235,6 +243,16 @@ void gui_flightdetail_item(uint8_t idx, char * text, uint8_t * flags, char * sub
 			}
 
 			sprintf_P(sub_text, PSTR("%0.1fm/s"), log_stat.max_climb / 100.0 );
+		break;
+		case 7:
+			strcpy_P(text, PSTR("Odometer:"));
+			if (log_odo == LOG_NODATA_i16)
+			{
+				sprintf_P(sub_text, PSTR("<no data>"));
+				break;
+			}
+
+			sprintf_P(sub_text, PSTR("%0.1fkm"), log_odo / (100 * 1000.0));
 		break;
 //		case 7:
 //			strcpy_P(text, PSTR("Delete"));

--- a/updates/changelog.txt
+++ b/updates/changelog.txt
@@ -1,6 +1,8 @@
+
 Build 40XX - XX. XX. 2018
 ========================================================
 ADDED:
+ * Count odometer during flight, save to log, #357 (bubeck)
  * Alarm 3 as an upper limit #348 (bubeck)
 
 Build 4016 - 24. 07. 2018


### PR DESCRIPTION
The odometer at the beginning of the flight is saved and used to
compute the distance travelled on the flight after the landing.
This data is stored in the log file and shown in the flight log
after selecting a log file during file_details.
    
This fixes https://github.com/fhorinek/SkyDrop/issues/357
    
It increases the following sizes:
    gcc version 7.2.0 (Fedora 7.2.0-1.fc28)
    
    Mem     size-before     size-after      delta    limit
    Flash   186514          186784          +270    196608
    RAM      11922           11930            +8     13107
    EEPROM     773             773             0      2048
