### PR TITLE
Change merge driver for changelog.txt to avoid conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/updates/changelog.txt merge=union


### PR DESCRIPTION
Whenver two branches change the changelog.txt we get a git conflict.
By changing the merge driver to "union" we will not get a conflict.
Instead the driver merges the union of all changes into the file.

more info at http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/