### PR TITLE
Allow "1000ft GND" as a height and optimize visualize

### DIFF
--- a/skydrop/utils/airspace/convert.py
+++ b/skydrop/utils/airspace/convert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- mode: python-mode; python-indent-offset: 4 -*-
 #*****************************************************************************
-# dnf install python3-shapely python3-gdal
+# dnf install python3-shapely python3-gdal python3-matplotlib
 #
 # This program is used to read a "Open-Airspace-file" containing a number of
 # airspaces and then computing a raster of positions around these airspaces.
@@ -608,7 +608,10 @@ def ReadAltFt( poFeature, fieldName ):
                     alt = int(m.group(1))
                     unit = m.group(2)
                     level = m.group(3)
+                    if level == "GND":
+                        level = "AGL"
                 else:
+                    # "1000ft"
                     m = re.match('(\d+)\s*(\w+)', alt)
                     if m != None:
                         alt = int(m.group(1))
@@ -616,6 +619,9 @@ def ReadAltFt( poFeature, fieldName ):
                         if level == "ft":
                             unit = level
                             level = "MSL"
+                        elif level == "GND":
+                            unit = "ft"
+                            level = "AGL"
                         else:
                             unit = "ft"
                     else:

--- a/skydrop/utils/airspace/spoof.py
+++ b/skydrop/utils/airspace/spoof.py
@@ -15,9 +15,13 @@ class GPS_Spoof(object):
         self.heading = 0
         self.speed = 0
         self.last_point = None
-        
-        self.port = serial.Serial(port, 9600)
-        
+
+        try:
+            self.port = serial.Serial(port, 9600)
+        except serial.serialutil.SerialException as se:
+            print (se)
+            print ("No GPS spoofing to SkyDrop...")
+            self.port = None
 
     def send_point(self, latitude, longitude, alt):
         utc = datetime.utcnow()
@@ -70,7 +74,8 @@ class GPS_Spoof(object):
             cs ^= n 
             
         line = bytes("$%s*%02X\r\n" % (s, cs), "utf-8")
-        self.port.write(line)
+        if self.port != None:
+            self.port.write(line)
 
         s = "GPGGA,,,,,,,5,1,%d,,10" % alt
         cs = 0
@@ -79,7 +84,8 @@ class GPS_Spoof(object):
             cs ^= n 
             
         line = bytes("$%s*%02X\r\n" % (s, cs), "utf-8")
-        self.port.write(line)
+        if self.port != None:
+            self.port.write(line)
 
         s = "GPGSA,,3"
         cs = 0
@@ -89,7 +95,8 @@ class GPS_Spoof(object):
             
         line = bytes("$%s*%02X\r\n" % (s, cs), "utf-8")
         
-        self.port.write(line)
+        if self.port != None:
+            self.port.write(line)
  
         
     

--- a/skydrop/utils/airspace/visualize.py
+++ b/skydrop/utils/airspace/visualize.py
@@ -1,15 +1,23 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
-# This script can be used to visualize the content of an AIR file
-# containing airspace data. It will draw a map showing the contents of
-# the file as a raster with points and arrows.
+# This script can be used to visualize and inspect the content of a
+# generated AIR file containing airspace data. It will first read
+# airspace data from an OpenAirspace file to draw all airspaces into
+# the map. By using the right mouse button, you can check this point.
+# It will open the corresponding AIR file of this point and output all
+# data previously generated for this point.
 #
-# It takes two arguments:
-#   1. a filename of an AIR file
-#   2. [optional] a level to visualize, which can be number from 0-4.
+# Additionally it will try to open the serial device /dev/ttyUSB1
+# which could be connected to a SkyDrop's GPS serial port. By clicking
+# on a point the GPS position will be sent to the SkyDrop. This allows
+# to see the reaction of the SkyDrop when it is at this position.
+#
+# It takes 1 arguments:
+#   1. a filename of the OpenAirspace file used to generated
 #
 # 20.12.2018: tilmann@bubecks.de
+# 03.06.2019: Updated version to read OpenAirspace and AIR
 
 from math import sqrt,cos,atan2,floor,sin,asin
 import re
@@ -347,6 +355,8 @@ def ReadAltFt( poFeature, fieldName ):
                     alt = int(m.group(1))
                     unit = m.group(2)
                     level = m.group(3)
+                    if level == "GND":
+                        level = "AGL"
                 else:
                     m = re.match('(\d+)\s*(\w+)', alt)
                     if m != None:
@@ -355,6 +365,9 @@ def ReadAltFt( poFeature, fieldName ):
                         if level == "ft":
                             unit = level
                             level = "MSL"
+                        elif level == "GND":
+                            unit = "ft"
+                            level = "AGL"
                         else:
                             unit = "ft"
                     else:
@@ -492,7 +505,7 @@ def ev(event):
     lon = event.xdata
     if lat is None or lon is None:
         return
-    if event.button == 1:
+    if event.button == 3:      # Right mouse button
         get_point(lat, lon)
         spf.send_point(lat, lon, galt)
         


### PR DESCRIPTION
German maps uses "1000ft GND" or "1000 GND" as a height level. Extend
parser to allow this.
Allow visualize to work without /dev/ttyUSB1 and use right button for
selecting a point. The previous left button disables zooming.