### PR TITLE
Fix temperature readings from SH21

### DIFF
--- a/skydrop/src/drivers/sensors/sht21.cpp
+++ b/skydrop/src/drivers/sensors/sht21.cpp
@@ -91,7 +91,7 @@ bool SHT21::Read()
 void SHT21::CompensateTemperature()
 {
 //	DEBUG("RT -- %u\n", this->raw_temperature);
-	float tmp = -46.85 -5 + 175.72 * ((float)this->raw_temperature / 65536.0);
+	float tmp = -46.85 + 175.72 * ((float)this->raw_temperature / 65536.0);
 //	DEBUG("  %0.2f\n", tmp);
 	this->temperature = tmp * 10;
 }


### PR DESCRIPTION
I have checked the SHT21 sensor's datasheet and in your code there is a -5 extra value in the temperature calculation function. Like this the temperature output of the vario is inaccurate and shows with 5 Celsius lower temperatures than in real. I have experienced the problem with my vario with the latest firmware. Please fix it. Thanks!