### PR TITLE
Battery widget now shows remaining runtime in minutes

### DIFF
--- a/skydrop/src/drivers/battery.cpp
+++ b/skydrop/src/drivers/battery.cpp
@@ -50,18 +50,28 @@ bool bat_cal_available = false;
 uint8_t battery_calibrating_state = BATTERY_CAL_BOOT;
 
 /**
- * Check, if we have calibration data for the battery in EEPROM.
+ * Return the number of minutes, that the battery runs, if full.
  *
- * @return true if data is available, false otherwise.
+ * @return number of minutes for full capacity
  */
-bool bat_calibrated()
+uint16_t bat_runtime_minutes()
 {
 	uint16_t value;
 
 	eeprom_busy_wait();
 	value = eeprom_read_word(&config_ro.bat_runtime_minutes);
 	DEBUG("config_ro.bat_runtime_minutes=%u\n", value);
-	return ( value != 0xffff );
+	return value;
+}
+
+/**
+ * Check, if we have calibration data for the battery in EEPROM.
+ *
+ * @return true if data is available, false otherwise.
+ */
+bool bat_calibrated()
+{
+	return ( bat_runtime_minutes() != 0xffff );
 }
 
 /**

--- a/skydrop/src/drivers/battery.h
+++ b/skydrop/src/drivers/battery.h
@@ -33,4 +33,18 @@ void battery_init();
 bool battery_step();
 void battery_force_update();
 
+/**
+ * Return the number of minutes, that the battery runs, if full.
+ *
+ * @return number of minutes for full capacity
+ */
+uint16_t bat_runtime_minutes();
+
+/**
+ * Check, if we have calibration data for the battery in EEPROM.
+ *
+ * @return true if data is available, false otherwise.
+ */
+bool bat_calibrated();
+
 #endif /* BATTERY_H_ */

--- a/skydrop/src/gui/widgets/battery.cpp
+++ b/skydrop/src/gui/widgets/battery.cpp
@@ -5,16 +5,24 @@
 void widget_battery_draw(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t flags)
 {
 	uint8_t lh = widget_label_P(PSTR("Bat"), x, y);
+	char text1[8];
+	char text2[8] = { 0 };
 
-	char text[8];
 	if (battery_per == BATTERY_CHARGING)
-		strcpy_P(text, PSTR("Chrg"));
+		strcpy_P(text1, PSTR("Chrg"));
 	else if (battery_per == BATTERY_FULL)
-		strcpy_P(text, PSTR("Full"));
+		strcpy_P(text1, PSTR("Full"));
 	else
-		sprintf_P(text, PSTR("%d%%"), battery_per);
+	{
+		sprintf_P(text1, PSTR("%d%%"), battery_per);
+		if (bat_calibrated())
+			sprintf_P(text2, PSTR("%dmin"), bat_runtime_minutes() * battery_per / 100);
+	}
 
-	widget_value_txt(text, x, y + lh, w, h - lh);
+	if (text2[0])
+		widget_value_txt2(text1, text2, x, y + lh, w, h - lh);
+	else
+		widget_value_txt(text1, x, y + lh, w, h - lh);
 }
 
 register_widget1(w_battery, "Battery", widget_battery_draw);

--- a/skydrop/src/gui/widgets/widgets.cpp
+++ b/skydrop/src/gui/widgets/widgets.cpp
@@ -264,7 +264,7 @@ void widget_value_int(char * value, uint8_t x, uint8_t y, uint8_t w, uint8_t h)
  *
  * \param value the text to be shown.
  * \param x the X coordinate of the box
- * \param y the X coordinate of the box
+ * \param y the Y coordinate of the box
  * \param w the width of the box
  * \param h the height of the box
  */

--- a/updates/changelog.txt
+++ b/updates/changelog.txt
@@ -3,8 +3,11 @@ Build XXXX - XX. XX. 2019
 ADDED:
  * Long middle button press on HAGL widget resets
    altitude1 to ground level. This can be used to
-   calibrate altitude1 when standing on ground.
-
+   calibrate altitude1 when standing on ground (bubeck)
+ * Battery widget now shows remaining runtime in
+   minutes (in addition to percent), if battery
+   is calibrated (bubeck)
+   
 FIX:
  * AGL fixed (bubeck)
  


### PR DESCRIPTION
The percentage of the battery is still shown. Runtime is only
shown if battery has been calibrated.