### PR TITLE
Flight log files (e.g. IGC) now contain temperature

### DIFF
--- a/skydrop/src/fc/fc.cpp
+++ b/skydrop/src/fc/fc.cpp
@@ -879,4 +879,6 @@ void fc_log_battery()
 		logger_comment(PSTR("bat: full"));
 	else
 		logger_comment(PSTR("bat: %u%% (%u)"),  battery_per, battery_adc_raw);
+
+	logger_comment(PSTR("temp: %d %d%%"), fc.temp.temp / 10, fc.temp.humid / 100);
 }

--- a/updates/changelog.txt
+++ b/updates/changelog.txt
@@ -1,6 +1,8 @@
 Build XXXX - XX. XX. 2019
 ========================================================
 ADDED:
+ * Flight log files (e.g. IGC) now contain temperature
+   inside a comment every 5 minutes (like battery level)
  * Long middle button press on HAGL widget resets
    altitude1 to ground level. This can be used to
    calibrate altitude1 when standing on ground.


### PR DESCRIPTION
inside a comment every 5 minutes (like battery level)