### PR TITLE
Removed widget Home>Info

### DIFF
--- a/skydrop/doc/manual/Manual-of-SkyDrop.md
+++ b/skydrop/doc/manual/Manual-of-SkyDrop.md
@@ -160,8 +160,6 @@ During startup animation, firmware version in bottom left and hardware revision 
 
 **Home Time** shows the time needed to get to _HOME_. This only shows up, if you fly towards _HOME_.
 
-**Home Info** Some textual information about _HOME_, taken from the home data file.
-
 **Waypoint arrow** shows the direction, where the next waypoint is.
 
 **Waypoint distance** shows the distance in miles/km to the next waypoint.

--- a/skydrop/src/gui/widgets/navigation.cpp
+++ b/skydrop/src/gui/widgets/navigation.cpp
@@ -163,39 +163,6 @@ void widget_waypoint_time_draw(uint8_t x, uint8_t y, uint8_t w, uint8_t h)
 	widget_nav_time_draw(PSTR("WP"), sec, x, y, w, h);
 }
 
-void widget_home_info_draw(uint8_t x, uint8_t y, uint8_t w, uint8_t h)
-{
-	uint8_t lh = widget_label_P(PSTR("Home"), x, y);
-
-	char text[21];
-	//strings are not always n null term
-	text[20] = 0;
-
-	if (config.home.flags & HOME_TAKEOFF)
-	{
-		strcpy_P(text, PSTR("Take off"));
-	}
-	else if(config.home.flags  & HOME_LOADED)
-	{
-		strcpy(text, (char *)config.home.name);
-	}
-	else
-	{
-		strcpy_P(text, PSTR("Load"));
-	}
-
-	widget_value_txt(text, x, y + lh, w, h - lh);
-}
-
-void widget_home_info_irqh(uint8_t type, uint8_t * buff)
-{
-	if (type == B_MIDDLE && *buff == BE_LONG)
-	{
-		gui_switch_task(GUI_NAVIGATION);
-		gui_list_set_index(GUI_NAVIGATION, 4);
-	}
-}
-
 void widget_waypoint_info_irqh(uint8_t type, uint8_t * buff)
 {
 	if (type == TASK_IRQ_BUTTON_L || type == TASK_IRQ_BUTTON_R)
@@ -428,7 +395,6 @@ register_widget2(w_odo_meter, "Odometer", widget_odometer_draw, 0, widget_odomet
 register_widget1(w_odo_home_direction, "Home Arrow", widget_home_arrow_draw);
 register_widget1(w_odo_home_distance, "Home Distance", widget_home_distance_draw);
 register_widget1(w_odo_home_time, "Home Time", widget_home_time_draw);
-register_widget2(w_home_info, "Home Info", widget_home_info_draw, 0, widget_home_info_irqh);
 
 register_widget1(w_waypoint_direction, "Waypoint Arrow", widget_waypoint_direction_draw);
 register_widget1(w_waypoint_distance, "Waypoint Distance", widget_waypoint_distance_draw);

--- a/skydrop/src/gui/widgets/navigation.h
+++ b/skydrop/src/gui/widgets/navigation.h
@@ -15,7 +15,6 @@ extern widget w_odo_meter;
 extern widget w_odo_home_direction;
 extern widget w_odo_home_distance;
 extern widget w_odo_home_time;
-extern widget w_home_info;
 extern widget w_waypoint_direction;
 extern widget w_waypoint_distance;
 extern widget w_waypoint_time;

--- a/skydrop/src/gui/widgets/widgets.cpp
+++ b/skydrop/src/gui/widgets/widgets.cpp
@@ -31,7 +31,7 @@ widget widget_array[NUMBER_OF_WIDGETS] = {
 		//agl
 		w_agl_height, w_agl_ground_level,
 		//odometer
-		w_odo_meter, w_odo_home_direction, w_odo_home_distance, w_odo_home_time, w_home_info,
+		w_odo_meter, w_odo_home_direction, w_odo_home_distance, w_odo_home_time,
 		//compass
 		w_compass_heading, w_compass_arrow, w_compass_points,
 		//thermal
@@ -86,7 +86,6 @@ const uint8_t PROGMEM widget_sorted[NUMBER_OF_SORTED_WIDGETS] =
 	WIDGET_ODO_BACK,
 	WIDGET_ODO_DISTANCE,
 	WIDGET_HOME_TIME,
-	WIDGET_HOME_INFO,
   
    //waypoints
 	WIDGET_WAYPOINT_ARROW,

--- a/skydrop/src/gui/widgets/widgets.h
+++ b/skydrop/src/gui/widgets/widgets.h
@@ -108,30 +108,29 @@ extern float widget_menu_fvalue1;
 #define WIDGET_ODO_BACK			32
 #define WIDGET_ODO_DISTANCE		33
 #define WIDGET_HOME_TIME		34
-#define WIDGET_HOME_INFO		35
 #include <gui/widgets/navigation.h>
 
-#define WIDGET_COMPASS			36
-#define WIDGET_COMPASS_ARROW	37
-#define WIDGET_COMPASS_POINTS	38
+#define WIDGET_COMPASS			35
+#define WIDGET_COMPASS_ARROW	36
+#define WIDGET_COMPASS_POINTS	37
 #include "compass.h"
 
-#define WIDGET_THERMAL_TIME     39
-#define WIDGET_THERMAL_GAIN     40
-#define WIDGET_THERMAL_ASS      41
+#define WIDGET_THERMAL_TIME     38
+#define WIDGET_THERMAL_GAIN     39
+#define WIDGET_THERMAL_ASS      40
 #include "thermal.h"
 
-#define WIDGET_WAYPOINT_ARROW       42
-#define WIDGET_WAYPOINT_DISTANCE    43
-#define WIDGET_WAYPOINT_TIME        44
-#define WIDGET_WAYPOINT_INFO        45
+#define WIDGET_WAYPOINT_ARROW       41
+#define WIDGET_WAYPOINT_DISTANCE    42
+#define WIDGET_WAYPOINT_TIME        43
+#define WIDGET_WAYPOINT_INFO        44
 
-#define WIDGET_AIRSPACE_INFO	    46
+#define WIDGET_AIRSPACE_INFO	    45
 #include "airspace.h"
 
-#define NUMBER_OF_WIDGETS			47
+#define NUMBER_OF_WIDGETS			46
 
-#define NUMBER_OF_SORTED_WIDGETS	47
+#define NUMBER_OF_SORTED_WIDGETS	46
 
 /**
  * Format a distance in a human readable format.

--- a/updates/changelog.txt
+++ b/updates/changelog.txt
@@ -4,6 +4,7 @@ Build XXXX - DD. MM. 2020
 FIX:
  * "Airspace>Alert near" setting did not show current
    value (bubeck)
+ * Removed widget Home>Info
 
 Build 5179 - 09. 05. 2020
 ========================================================


### PR DESCRIPTION
With the introduction of waypoint navigation, many information about
loaded home position was removed. Therefore Home>Info has nothing to
show anymore and this patch removes it.

This saves the following memory:

    gcc version 7.2.0 (Fedora 7.2.0-1.fc28)

    Mem     size-before     size-after      delta    limit
    Flash   193724          192934          -790    196608
    RAM       9781            9765           -16     13107
    EEPROM     647             647             0      2048