### PR TITLE
Prepare DISABLE_BLUETOOTH to remove bluetooth code if necessary.

### DIFF
--- a/skydrop/src/drivers/bluetooth/bt.cpp
+++ b/skydrop/src/drivers/bluetooth/bt.cpp
@@ -2,6 +2,8 @@
 
 #include "../../fc/conf.h"
 
+#ifndef DISABLE_BLUETOOTH
+
 #include "pan1322.h"
 #include "pan1026.h"
 
@@ -312,3 +314,26 @@ uint8_t bt_get_module_type()
 {
 	return bt_module_type;
 }
+
+#else
+
+volatile uint8_t bt_module_state = BT_MOD_STATE_OFF;
+
+bool bt_ready() { return false; }
+uint8_t bt_get_module_type() { return BT_PAN1322; }
+
+void bt_init() {}
+void bt_stop() {}
+void bt_step() {}
+
+void bt_module_reset() {}
+void bt_module_init() {}
+void bt_module_deinit() {}
+bool bt_device_active() { return false; }
+
+void bt_send(char * str) {}
+void bt_send(uint16_t len, uint8_t * data) {}
+void bt_irqh(uint8_t type, uint8_t * buf) {}
+
+#endif
+

--- a/skydrop/src/fc/conf.h
+++ b/skydrop/src/fc/conf.h
@@ -8,6 +8,9 @@
 #ifndef CONF_H_
 #define CONF_H_
 
+// Define this to disable code for bluetooth. Saves around 10k of code.
+// #define DISABLE_BLUETOOTH
+
 #include "../gui/widgets/widgets.h"
 #include "fc.h"
 


### PR DESCRIPTION
This is a conditional compile to remove bluetooth code, if space is needed (e.g. for DEBUG).
Standard is to use bluetooth and only remove if DISABLE_BLUETOOTH is defined in conf.h