### PR TITLE
Fix distance display

### DIFF
--- a/skydrop/src/gui/widgets/airspace.cpp
+++ b/skydrop/src/gui/widgets/airspace.cpp
@@ -87,12 +87,7 @@ void widget_airspace_info_draw(uint8_t x, uint8_t y, uint8_t w, uint8_t h)
 		widget_arrow(relative_direction, 0, 18 + y_spc / 2, 22, 20);
 
 		//Distance
-		sprintf_distance(text1, fc.airspace.distance_m / 1000.0);
-		if (config.connectivity.gps_format_flags & GPS_DIST_UNIT_I)
-			strcpy_P(text2, PSTR("mi"));
-		else
-			strcpy_P(text2, PSTR("km"));
-
+		sprintf_distance(text1, text2, fc.airspace.distance_m / 1000.0);
 		widget_value_int_sub(text1, text2, w - 60, 18 + y_spc / 2, 20, 20);
 	}
 	else

--- a/skydrop/src/gui/widgets/navigation.cpp
+++ b/skydrop/src/gui/widgets/navigation.cpp
@@ -29,16 +29,24 @@ const uint8_t PROGMEM img_distance[] =
 
 #define NAV_INFO_PERIOD		10000
 
+void widget_distance_draw(const char *label_P, float distance, uint8_t x, uint8_t y, uint8_t w, uint8_t h)
+{
+	uint8_t lh = widget_label_P(label_P, x, y);
+#ifndef DISABLE_ICONS
+	if (lh > 0)
+		disp.DrawImage(img_distance, x + 1 + disp.GetTextWidth_P(label_P) + 2, y);
+#endif
+
+	char text1[12];
+	char text2[12];
+
+	sprintf_distance(text1, text2, distance);
+	widget_value_txt2(text1, text2, x, y + lh, w, h - lh);
+}
+
 void widget_odometer_draw(uint8_t x, uint8_t y, uint8_t w, uint8_t h)
 {
-	uint8_t lh = widget_label_P(PSTR("Odo"), x, y);
-
-	char text[10];
-
-	float distance = fc.odometer / 1000.0;        // cm to km
-	sprintf_distance(text, distance);
-
-	widget_value_txt(text, x, y + lh, w, h - lh);
+  widget_distance_draw(PSTR("Odo"), fc.odometer / 1000.0, x, y, w, h);
 }
 
 void widget_odometer_irqh(uint8_t type, uint8_t * buff)
@@ -51,28 +59,6 @@ void widget_odometer_irqh(uint8_t type, uint8_t * buff)
 			fc.odometer = 0;
 		}
 	}
-}
-
-void widget_distance_draw(const char *label_P, float distance, uint8_t x, uint8_t y, uint8_t w, uint8_t h)
-{
-	uint8_t lh = widget_label_P(label_P, x, y);
-#ifndef DISABLE_ICONS
-	if (lh > 0)
-		disp.DrawImage(img_distance, x + 1 + disp.GetTextWidth_P(label_P) + 2, y);
-#endif
-
-	char text[10];
-
-	if (distance != INFINITY)
-	{
-		sprintf_distance(text, distance);
-	}
-	else
-	{
-		sprintf_P(text, PSTR("---"));
-	}
-
-	widget_value_txt(text, x, y + lh, w, h - lh);
 }
 
 void widget_home_distance_draw(uint8_t x, uint8_t y, uint8_t w, uint8_t h)

--- a/skydrop/src/gui/widgets/widgets.cpp
+++ b/skydrop/src/gui/widgets/widgets.cpp
@@ -125,24 +125,32 @@ const uint8_t PROGMEM widget_sorted[NUMBER_OF_SORTED_WIDGETS] =
 /**
  * Format a distance in a human readable format.
  *
- * @param text the text buffer to print into.
+ * @param text_number the text buffer to print the value into.
+ * @param text_unit the text buffer to print the unit into.
  * @param distance the distance in km.
  */
-void sprintf_distance(char *text, float distance)
+void sprintf_distance(char *text_number, char *text_unit, float distance)
 {
-	if (config.connectivity.gps_format_flags & GPS_DIST_UNIT_I)
+	if (distance != INFINITY)
 	{
-		distance *= FC_KM_TO_MILE;
-	}
+		if (config.connectivity.gps_format_flags & GPS_DIST_UNIT_I)
+	    {
+			distance *= FC_KM_TO_MILE;
+			strcpy_P(text_unit, PSTR("mi"));
+	    } else
+	        strcpy_P(text_unit, PSTR("km"));
 
-	if (distance < 1.0 && !(config.connectivity.gps_format_flags & GPS_DIST_UNIT_I))
-		sprintf_P(text, PSTR("%0.0fm"), distance * 1000);
-	else if (distance < 10.0)
-		sprintf_P(text, PSTR("%.2f"), distance);
-	else if (distance < 100.0)
-		sprintf_P(text, PSTR("%.1f"), distance);
-	else
-		sprintf_P(text, PSTR("%.0f"), distance);
+		if (distance < 10.0)
+			sprintf_P(text_number, PSTR("%.2f"), distance);
+		else if (distance < 100.0)
+			sprintf_P(text_number, PSTR("%.1f"), distance);
+		else
+			sprintf_P(text_number, PSTR("%.0f"), distance);
+
+	} else {
+		strcpy_P(text_number, PSTR("---"));
+		text_unit[0] = 0;
+	}
 }
 
 uint8_t widget_sorted_get_index(uint8_t pos)

--- a/skydrop/src/gui/widgets/widgets.h
+++ b/skydrop/src/gui/widgets/widgets.h
@@ -136,10 +136,11 @@ extern float widget_menu_fvalue1;
 /**
  * Format a distance in a human readable format.
  *
- * @param text the text buffer to print into.
+ * @param text_number the text buffer to print the value into.
+ * @param text_unit the text buffer to print the unit into.
  * @param distance the distance in km.
  */
-extern void sprintf_distance(char *text, float distance);
+extern void sprintf_distance(char *text_number, char *text_unit, float distance);
 
 extern const uint8_t PROGMEM widget_sorted[NUMBER_OF_SORTED_WIDGETS];
 uint8_t widget_sorted_get_index(uint8_t pos);


### PR DESCRIPTION
If distance is ^GPS_DIST_UNIT_I and distance <1km, then there are two bugs:
  1. Widget "airspace" shows "100km" for 100m, which is obviously wrong.
     Additionally "m" is appended to 100.
  2. Widget "odo" shows a unit, e.g. "100m" and no unit if > 1km

This patch fixes both bugs and saves some PROGMEM.