### PR TITLE
Increase accuracy of gps_distance from meter to cm.

### DIFF
--- a/skydrop/src/fc/airspace.cpp
+++ b/skydrop/src/fc/airspace.cpp
@@ -462,7 +462,7 @@ void airspace_get_data_on_opened_file(int32_t lat, int32_t lon)
 
         bool use_fai = config.connectivity.gps_format_flags & GPS_EARTH_MODEL_FAI;
         int16_t angle;
-        uint16_t distance = gps_distance(lat, lon, ty, tx, use_fai, &angle);
+        uint16_t distance = gps_distance(lat, lon, ty, tx, use_fai, &angle) / 100;   // cm to m
 
         if (fc.airspace.cache[i].flags & AIR_CACHE_FAR)
         	distance = AIRSPACE_TOO_FAR;

--- a/skydrop/src/fc/fc.cpp
+++ b/skydrop/src/fc/fc.cpp
@@ -465,7 +465,7 @@ void fc_save_stats()
 	logger_comment(PSTR(" SKYDROP-ALT-MIN-m: %d "), fc.flight.stats.min_alt);
 	logger_comment(PSTR(" SKYDROP-CLIMB-MAX-cm: %d "), fc.flight.stats.max_climb);
 	logger_comment(PSTR(" SKYDROP-SINK-MAX-cm: %d "), fc.flight.stats.max_sink);
-	logger_comment(PSTR(" SKYDROP-ODO-m: %lu "), fc.odometer - fc.flight.autostart_odo);
+	logger_comment(PSTR(" SKYDROP-ODO-m: %lu "), (fc.odometer - fc.flight.autostart_odo)/100);   // cm to m
 }
 
 void fc_end_hike()

--- a/skydrop/src/fc/fc.h
+++ b/skydrop/src/fc/fc.h
@@ -453,7 +453,7 @@ struct flight_computer_data_t
 
 	airspace_data_t airspace;
 
-	uint32_t odometer;              // in m
+	uint32_t odometer;              // in cm
 
 	uint8_t logger_state;           // One of the LOGGER_IDLE, LOGGER_WAIT_FOR_GPS, ...
 

--- a/skydrop/src/fc/navigation.cpp
+++ b/skydrop/src/fc/navigation.cpp
@@ -59,7 +59,7 @@ void gps_destination(float lat1, float lon1, float angle, float distance_km,
  * \param FAI use FAI sphere instead of WGS ellipsoid
  * \param bearing pointer to bearing (NULL if not used)
  *
- * \return the distance in m.
+ * \return the distance in cm.
  */
 uint32_t gps_distance(int32_t lat1, int32_t lon1,
 			 	 	  int32_t lat2, int32_t lon2, bool FAI, int16_t * bearing)
@@ -94,7 +94,7 @@ uint32_t gps_distance(int32_t lat1, int32_t lon1,
 
 //		DEBUG("#q=%0.10f\n", q);
 
-		dist = 2 * FAI_EARTH_RADIUS * asin(sqrt(q)) * 1000.0;
+		dist = 2 * FAI_EARTH_RADIUS * asin(sqrt(q)) * 100000.0;
 	}
 	else //WGS
 	{
@@ -113,7 +113,7 @@ uint32_t gps_distance(int32_t lat1, int32_t lon1,
 //		DEBUG("#d_lon=%0.10f\n", d_lon);
 //		DEBUG("#d_lat=%0.10f\n", d_lat);
 
-        dist = sqrt(pow(d_lon, 2) + pow(d_lat, 2)) * 1000.0;
+        dist = sqrt(pow(d_lon, 2) + pow(d_lat, 2)) * 100000.0;
 	}
 
     if (bearing)
@@ -177,7 +177,7 @@ void navigation_step()
 
 		fc.flight.home_distance = gps_distance(fc.gps_data.latitude, fc.gps_data.longtitude,
 											   config.home.lat, config.home.lon,
-											   use_fai, (int16_t *)&fc.flight.home_bearing) / 1000.0;   // m to km
+											   use_fai, (int16_t *)&fc.flight.home_bearing) / 100000.0;   // cm to km
 	}
 
 	if (waypoint_task_active())
@@ -206,11 +206,11 @@ void navigation_step()
 			//get optimal points
 			wpt_dist = gps_distance(fc.gps_data.latitude, fc.gps_data.longtitude,
 					fc.task.next_waypoint.twpt.opti_latitude, fc.task.next_waypoint.twpt.opti_longtitude,
-					use_fai, (int16_t *)&fc.task.next_waypoint.bearing);
+					use_fai, (int16_t *)&fc.task.next_waypoint.bearing) / 100;    // cm to m
 
 			center_dist = gps_distance(fc.gps_data.latitude, fc.gps_data.longtitude,
 					fc.task.next_waypoint.twpt.wpt.latitude, fc.task.next_waypoint.twpt.wpt.longtitude,
-					use_fai, NULL);
+					use_fai, NULL) / 100;    // cm to m
 
 			DEBUG("n %lu %lu\n", fc.task.next_waypoint.twpt.opti_latitude, fc.task.next_waypoint.twpt.opti_longtitude);
 		}
@@ -219,7 +219,7 @@ void navigation_step()
 			//get center points
 			wpt_dist = gps_distance(fc.gps_data.latitude, fc.gps_data.longtitude,
 					fc.task.next_waypoint.twpt.wpt.latitude, fc.task.next_waypoint.twpt.wpt.longtitude,
-					use_fai, (int16_t *)&fc.task.next_waypoint.bearing);
+					use_fai, (int16_t *)&fc.task.next_waypoint.bearing) / 100;    // cm to m
 
 			center_dist = wpt_dist;
 
@@ -280,8 +280,8 @@ void navigation_step()
 		bool use_fai = config.connectivity.gps_format_flags & GPS_EARTH_MODEL_FAI;
 		uint32_t v = gps_distance(last_lat, last_lon, fc.gps_data.latitude, fc.gps_data.longtitude, use_fai);
 
-		//calculated speed in knots. The distance "v" is in meter and we get a GPS sample every second, so this is meter per second.
-		float calc_speed = v * FC_MPS_TO_KNOTS;
+		//calculated speed in knots. The distance "v" is in centimeter and we get a GPS sample every second, so this is meter per second.
+		float calc_speed = v / 100.0 * FC_MPS_TO_KNOTS;
 
 		//do not add when gps speed is < 1 km/h
 		//do not add when difference between calculated speed and gps speed is > 10 km/h

--- a/skydrop/src/fc/waypoint.cpp
+++ b/skydrop/src/fc/waypoint.cpp
@@ -488,7 +488,7 @@ void waypoint_task_calc_distance()
 		waypoint_task_get_wpt(i, &twpt);
 
 		bool use_fai = fc.task.head.flags & CFG_TASK_FLAGS_FAI_SPHERE;
-		twpt.dist_m = gps_distance(lat, lon, twpt.wpt.latitude, twpt.wpt.longtitude, use_fai);
+		twpt.dist_m = gps_distance(lat, lon, twpt.wpt.latitude, twpt.wpt.longtitude, use_fai) / 100;   // cm to m
 		fc.task.head.center_dist_m += twpt.dist_m;
 
 		lat = twpt.wpt.latitude;
@@ -524,7 +524,7 @@ uint32_t waypoint_task_opti_distance(opti_waypoint_cache_t * twpt1, opti_waypoin
 	int32_t lon2 = twpt2->opti_longtitude;
 
 	bool use_fai = fc.task.head.flags & CFG_TASK_FLAGS_FAI_SPHERE;
-	return gps_distance(lat1, lon1, lat2, lon2, use_fai, NULL);
+	return gps_distance(lat1, lon1, lat2, lon2, use_fai, NULL) / 100;  // cm to m
 }
 
 #define TASK_OPTI_INVALID	0xFF
@@ -833,7 +833,7 @@ void waypoint_task_optimise_finalise()
 		int32_t lat2 = twpt.opti_latitude;
 
 		bool use_fai = fc.task.head.flags & CFG_TASK_FLAGS_FAI_SPHERE;
-		twpt.opti_dist_m = gps_distance(lat1, lon1, lat2, lon2, use_fai, NULL);
+		twpt.opti_dist_m = gps_distance(lat1, lon1, lat2, lon2, use_fai, NULL) / 100;  // cm to m
 
 		lon1 = lon2;
 		lat1 = lat2;

--- a/skydrop/src/gui/widgets/navigation.cpp
+++ b/skydrop/src/gui/widgets/navigation.cpp
@@ -46,7 +46,7 @@ void widget_distance_draw(const char *label_P, float distance, uint8_t x, uint8_
 
 void widget_odometer_draw(uint8_t x, uint8_t y, uint8_t w, uint8_t h)
 {
-  widget_distance_draw(PSTR("Odo"), fc.odometer / 1000.0, x, y, w, h);
+  widget_distance_draw(PSTR("Odo"), fc.odometer / 100000.0, x, y, w, h);   // cm to km
 }
 
 void widget_odometer_irqh(uint8_t type, uint8_t * buff)


### PR DESCRIPTION
This is important for odometer, especially when hiking.
As we compute the distance every second, we get a huge
error if we have accuracy of 1 meter instead of centimeter:

For a given flight, the previous implementation lead to
17.7km and with increased accuracy to 18.7km. This is an
error of 6%.

For hiking the error is much greater, because we only walk around 1m per second. So if we walk 1.5m per second, the error is 50%.
