### PR TITLE
Fix post_build.sh to work with any "avr-size" command

### DIFF
--- a/skydrop/utils/build/post_build.sh
+++ b/skydrop/utils/build/post_build.sh
@@ -1,30 +1,44 @@
 #!/bin/bash
 
+# print the size in bytes of the given section
+function size_sect()
+{
+    # skydrop.elf  :
+    # section                      size      addr
+    # .fw_info                       32   8454144
+    # .eeprom                       647   8454176
+    # .cfg_ro                       391   8455808
+    # [...]
+    avr-size --format=sysv skydrop.elf | grep $1 | awk '{ print $2 }'
+}
+
 echo " *** POST BUILD ***"
 echo
 
 echo " * Checking sizes"
-sizes=($(avr-size --format=avr --mcu=atxmega192a3u skydrop.elf | grep bytes | tr -s " " | cut -f2 -d " "))
 
 echo -e "Mem\tsize\tlimit"
 
 flash_limit=196608
-echo -e "Flash\t${sizes[0]}\t$flash_limit"
-if [ "${sizes[0]}" -gt "$flash_limit" ]; then #192kB
+flash_size=$(( $(size_sect .text) + $(size_sect .data) ))
+echo -e "Flash\t$flash_size\t$flash_limit"
+if [ "$flash_size" -gt "$flash_limit" ]; then #192kB
     echo "Program size 192kB exceeded!"
     exit
 fi
 
 ram_limit=13107
-echo -e "RAM\t${sizes[1]}\t$ram_limit"
-if [ "${sizes[1]}" -gt "$ram_limit" ]; then #80%
+ram_size=$(( $(size_sect .data) + $(size_sect .bss) + $(size_sect .noinit) ))
+echo -e "RAM\t$ram_size\t$ram_limit"
+if [ "$ram_size" -gt "$ram_limit" ]; then #80%
     echo "Data size 80% exceeded!"
     exit
 fi
 
 eeprom_limit=2048
-echo -e "EEPROM\t${sizes[2]}\t$eeprom_limit"
-if [ "${sizes[2]}" -gt "$eeprom_limit" ]; then #2kB
+eeprom_size=$(size_sect .eeprom)
+echo -e "EEPROM\t$eeprom_size\t$eeprom_limit"
+if [ "$eeprom_size" -gt "$eeprom_limit" ]; then #2kB
     echo "Eeprom size 2kB exceeded!"
     exit
 fi


### PR DESCRIPTION
Currently post_build.sh needs a special avr-size command
that is able to handle "--format=avr". This commit
gives more flexibility by using "--format=sysv" which is
available in all versions of avr-size.
Fixes https://github.com/fhorinek/SkyDrop/issues/439